### PR TITLE
Use WebView history for dashboard back

### DIFF
--- a/entry/src/main/ets/app/AppLifecycleRuntimeService.ets
+++ b/entry/src/main/ets/app/AppLifecycleRuntimeService.ets
@@ -12,6 +12,7 @@ export interface AppLifecycleRuntimeState {
   appUnlocking: boolean;
   dashboardUrl: string;
   dashboardCurrentUrl: string;
+  dashboardClearHistoryPending: boolean;
   authUrl: string;
   showLoginWeb: boolean;
   dashboardBridgeReady: boolean;
@@ -153,6 +154,7 @@ export class AppLifecycleRuntimeService {
   private static applyRestoreDecision(state: AppLifecycleRuntimeState, restoreDecision: StartupRestoreDecision): void {
     state.dashboardUrl = restoreDecision.dashboardUrl;
     state.dashboardCurrentUrl = restoreDecision.dashboardUrl;
+    state.dashboardClearHistoryPending = true;
     state.authUrl = restoreDecision.authUrl;
     state.showLoginWeb = restoreDecision.showLoginWeb;
     state.dashboardBridgeReady = restoreDecision.dashboardBridgeReady;

--- a/entry/src/main/ets/app/AppNavigationRuntimeService.ets
+++ b/entry/src/main/ets/app/AppNavigationRuntimeService.ets
@@ -1,7 +1,6 @@
 import { AppRoute } from './AppRoute';
 import { AppNavigator } from './AppNavigator';
 import { Localization } from '../shared/i18n/Localization';
-import { UrlService } from '../services/UrlService';
 
 export interface AppNavigationRuntimeState {
   showCompanionChoiceDialog: boolean;
@@ -17,7 +16,6 @@ export interface AppNavigationRuntimeState {
   showDeleteServerDialog: boolean;
   showServerEditDialog: boolean;
   nativeFeatureBackTarget: number;
-  dashboardCurrentUrl: string;
   connectionErrorBackTarget: number;
   connectionProbeToken: number;
 }
@@ -28,10 +26,8 @@ export interface AppNavigationRuntimeCallbacks {
   cancelAddServerFromSettings: () => void;
   stopDiscoveryAnimation: () => void;
   returnToHaSettingsPage: () => void;
-  currentDashboardUrl: () => string;
   canDashboardGoBack: () => boolean;
   dashboardGoBack: () => void;
-  runDashboardScript: (script: string) => void;
 }
 
 export class AppNavigationRuntimeService {
@@ -147,16 +143,11 @@ export class AppNavigationRuntimeService {
     state: AppNavigationRuntimeState,
     callbacks: AppNavigationRuntimeCallbacks
   ): boolean {
-    const currentUrl = callbacks.currentDashboardUrl();
-    if (UrlService.isDashboardHomeUrl(currentUrl)) {
-      return false;
-    }
     if (callbacks.canDashboardGoBack()) {
       callbacks.dashboardGoBack();
       return true;
     }
-    callbacks.runDashboardScript('history.back();');
-    return true;
+    return false;
   }
 
   private static isNativeSettingsRoute(route: number): boolean {

--- a/entry/src/main/ets/app/AppRuntimeCallbackFactory.ets
+++ b/entry/src/main/ets/app/AppRuntimeCallbackFactory.ets
@@ -60,7 +60,6 @@ export interface AppRuntimeCallbackTarget {
   setDiscoverySheetVisible(visible: boolean): void;
   cancelAddServerFromSettings(): void;
   returnToHaSettingsPage(): void;
-  currentDashboardUrl(): string;
   canDashboardGoBack(): boolean;
   dashboardGoBack(): void;
   tryRunWebScript(script: string): void;
@@ -244,10 +243,8 @@ export class AppRuntimeCallbackFactory {
       cancelAddServerFromSettings: (): void => target.cancelAddServerFromSettings(),
       stopDiscoveryAnimation: (): void => target.stopDiscoveryAnimation(),
       returnToHaSettingsPage: (): void => target.returnToHaSettingsPage(),
-      currentDashboardUrl: (): string => target.currentDashboardUrl(),
       canDashboardGoBack: (): boolean => target.canDashboardGoBack(),
-      dashboardGoBack: (): void => target.dashboardGoBack(),
-      runDashboardScript: (script: string): void => target.tryRunWebScript(script)
+      dashboardGoBack: (): void => target.dashboardGoBack()
     };
   }
 }

--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -186,6 +186,7 @@ export struct AppRuntimeHost {
   @State dashboardUrl: string = '';
   @State dashboardLoadedUrl: string = '';
   @State dashboardCurrentUrl: string = '';
+  @State dashboardClearHistoryPending: boolean = false;
   @State nativeSettingsReturnUrl: string = '';
   @State dashboardBackToHomePending: boolean = false;
   @State dashboardBridgeReady: boolean = false;
@@ -395,6 +396,7 @@ export struct AppRuntimeHost {
       if (shouldReload || this.dashboardUrl.trim().length === 0) {
         this.dashboardUrl = resolution.url;
         this.dashboardCurrentUrl = resolution.url;
+        this.dashboardClearHistoryPending = true;
         if (shouldReload || this.dashboardLoadedUrl.length === 0) {
           this.dashboardLoadedUrl = '';
         }
@@ -524,6 +526,17 @@ export struct AppRuntimeHost {
       return;
     }
     this.dashboardLoadedUrl = url;
+  }
+
+  clearPendingDashboardHistory(): void {
+    if (!this.dashboardClearHistoryPending) {
+      return;
+    }
+    try {
+      this.webCtrl.clearHistory();
+    } catch (_) {
+    }
+    this.dashboardClearHistoryPending = false;
   }
 
   openAssistConversation(payload: Object | string): void {
@@ -816,11 +829,13 @@ export struct AppRuntimeHost {
     this.dashboardLoadedUrl = '';
     setTimeout((): void => {
       if (this.step === AppRoute.DASHBOARD && this.dashboardUrl === targetUrl) {
+        this.dashboardClearHistoryPending = true;
         this.tryLoadWebUrl(targetUrl);
       }
     }, 0);
     setTimeout((): void => {
       if (this.step === AppRoute.DASHBOARD && this.dashboardUrl === targetUrl) {
+        this.dashboardClearHistoryPending = true;
         this.tryLoadWebUrl(targetUrl);
       }
     }, 250);

--- a/entry/src/main/ets/app/AppWebRuntimeService.ets
+++ b/entry/src/main/ets/app/AppWebRuntimeService.ets
@@ -30,6 +30,7 @@ export interface AppWebRuntimeActionTarget {
   handleBackNavigation(): boolean;
   applyDashboardPreferences(): void;
   installFrontendUrlObserver(): void;
+  clearPendingDashboardHistory(): void;
   rememberDashboardUrl(url: string): void;
   rememberDashboardLoadedUrl(url: string): void;
   retryDashboardSecurity(): void;
@@ -77,6 +78,7 @@ export class AppWebRuntimeService {
       onDashboardPageReady: (): void => {
         target.applyDashboardPreferences();
         target.installFrontendUrlObserver();
+        target.clearPendingDashboardHistory();
       },
       onRememberDashboardUrl: (url: string): void => target.rememberDashboardUrl(url),
       onDashboardLoadedUrlChange: (url: string): void => target.rememberDashboardLoadedUrl(url),

--- a/entry/src/main/ets/features/dashboard/DashboardRuntimeService.ets
+++ b/entry/src/main/ets/features/dashboard/DashboardRuntimeService.ets
@@ -11,6 +11,7 @@ export interface DashboardRuntimeState {
   authUrl: string;
   dashboardUrl: string;
   dashboardCurrentUrl: string;
+  dashboardClearHistoryPending: boolean;
   dashboardAuthProvided: boolean;
   pageZoomLevel: string;
   alwaysShowFirstViewOnAppStartEnabled: boolean;
@@ -33,6 +34,7 @@ export class DashboardRuntimeService {
     const baseUrl = UrlService.normalizeBaseUrl(state.haBaseUrl);
     state.dashboardUrl = UrlService.buildDashboardUrl(baseUrl);
     state.dashboardCurrentUrl = state.dashboardUrl;
+    state.dashboardClearHistoryPending = true;
     state.addingServerFromSettings = false;
     state.onboardingBackTarget = AppRoute.WELCOME;
     state.step = AppRoute.DASHBOARD;
@@ -143,6 +145,7 @@ export class DashboardRuntimeService {
     const url = UrlService.buildDashboardUrl(UrlService.normalizeBaseUrl(state.haBaseUrl));
     state.dashboardUrl = url;
     state.dashboardCurrentUrl = url;
+    state.dashboardClearHistoryPending = true;
     DashboardRuntimeService.loadUrl(controller, url);
   }
 }

--- a/entry/src/main/ets/services/UrlService.ets
+++ b/entry/src/main/ets/services/UrlService.ets
@@ -156,8 +156,4 @@ export class UrlService {
     return value.length > 0 ? value : '/';
   }
 
-  static isDashboardHomeUrl(url: string): boolean {
-    const path = UrlService.urlPathOnly(url);
-    return path === '/' || path === '/lovelace' || path === '/lovelace/default_view';
-  }
 }


### PR DESCRIPTION
## Summary

- Replace dashboard back handling with native WebView history behavior.
- Clear the dashboard WebView history after initial dashboard loads so the entry dashboard page exits to system Home/background instead of navigating inside Home Assistant.
- Remove the hard-coded dashboard home URL check from `UrlService`.

## Root Cause

The previous dashboard back boundary depended on a small hard-coded set of Home Assistant dashboard paths. That worked for the default dashboard but failed for custom dashboards because those paths were not recognized as home pages. The WebView would then consume system back instead of allowing the app to move to background.

