### PR TITLE
[codex] Update media card room indicator

### DIFF
--- a/entry/src/main/ets/features/cards/CardRuntimeCoordinator.ets
+++ b/entry/src/main/ets/features/cards/CardRuntimeCoordinator.ets
@@ -38,6 +38,7 @@ interface MediaFormData {
   title: string;
   subtitle: string;
   state: string;
+  areaName: string;
   mediaTitle: string;
   mediaArtist: string;
   appName: string;
@@ -45,7 +46,6 @@ interface MediaFormData {
   coverImageName: string;
   surfaceColor: string;
   primaryTextColor: string;
-  secondaryTextColor: string;
   disabledTextColor: string;
   trackColor: string;
   updateFrequency: string;
@@ -285,7 +285,6 @@ export class CardRuntimeCoordinator {
       'coverUrl': asset.localUrl,
       'surfaceColor': asset.palette.surfaceColor,
       'primaryTextColor': asset.palette.primaryTextColor,
-      'secondaryTextColor': asset.palette.secondaryTextColor,
       'disabledTextColor': asset.palette.disabledTextColor,
       'trackColor': asset.palette.trackColor
     });
@@ -324,6 +323,7 @@ export class CardRuntimeCoordinator {
       title: bound ? record.targetName : Localization.t('card_media_control_title'),
       subtitle: bound ? CardRuntimeCoordinator.mediaSubtitle(record, display) : Localization.t('card_bind_media_player'),
       state: bound ? record.state : 'unknown',
+      areaName: bound ? record.areaName : '',
       mediaTitle: bound ? CardRuntimeCoordinator.displayField(display, 'mediaTitle', record.targetName) : Localization.t('card_choose_player'),
       mediaArtist: bound ? CardRuntimeCoordinator.displayField(display, 'mediaArtist', record.areaName) : '',
       appName: CardRuntimeCoordinator.displayField(display, 'appName', ''),
@@ -331,7 +331,6 @@ export class CardRuntimeCoordinator {
       coverImageName: '',
       surfaceColor: bound ? CardRuntimeCoordinator.displayField(display, 'surfaceColor', CoverImageService.FALLBACK_PALETTE.surfaceColor) : '#FFFFFF',
       primaryTextColor: CardRuntimeCoordinator.displayField(display, 'primaryTextColor', CoverImageService.FALLBACK_PALETTE.primaryTextColor),
-      secondaryTextColor: CardRuntimeCoordinator.displayField(display, 'secondaryTextColor', CoverImageService.FALLBACK_PALETTE.secondaryTextColor),
       disabledTextColor: CardRuntimeCoordinator.displayField(display, 'disabledTextColor', CoverImageService.FALLBACK_PALETTE.disabledTextColor),
       trackColor: CardRuntimeCoordinator.displayField(display, 'trackColor', CoverImageService.FALLBACK_PALETTE.trackColor),
       updateFrequency: await AppSettingsStore.loadServiceCardUpdateFrequency(context),

--- a/entry/src/main/ets/widget/pages/HarmonyMediaServiceCard.ets
+++ b/entry/src/main/ets/widget/pages/HarmonyMediaServiceCard.ets
@@ -12,6 +12,7 @@ struct HarmonyMediaServiceCard {
   @LocalStorageProp('title') title: string = Localization.t('card_media_control_title');
   @LocalStorageProp('subtitle') subtitle: string = Localization.t('card_bind_media_player');
   @LocalStorageProp('state') state: string = 'unknown';
+  @LocalStorageProp('areaName') areaName: string = '';
   @LocalStorageProp('mediaTitle') mediaTitle: string = Localization.t('card_choose_player');
   @LocalStorageProp('mediaArtist') mediaArtist: string = '';
   @LocalStorageProp('appName') appName: string = '';
@@ -19,7 +20,6 @@ struct HarmonyMediaServiceCard {
   @LocalStorageProp('coverImageName') coverImageName: string = '';
   @LocalStorageProp('surfaceColor') surfaceColor: string = '#FFFFFF';
   @LocalStorageProp('primaryTextColor') primaryTextColor: string = ServiceCardUiConfig.textPrimary;
-  @LocalStorageProp('secondaryTextColor') secondaryTextColor: string = ServiceCardUiConfig.textSecondary;
   @LocalStorageProp('disabledTextColor') disabledTextColor: string = '#97A2AA';
   @LocalStorageProp('trackColor') trackColor: string = '#D7DEE4';
   @LocalStorageProp('updateFrequency') updateFrequency: string = 'default';
@@ -166,13 +166,33 @@ struct HarmonyMediaServiceCard {
   @Builder
   private contentArea(): void {
     Column() {
-      Column({ space: 3 }) {
+      Column({ space: 5 }) {
+        Row({ space: 4 }) {
+          if (this.roomNameText().length > 0) {
+            SymbolGlyph($r('sys.symbol.speaker_wave_3'))
+              .fontSize(23)
+              .fontColor([this.contentTranslucentColor()])
+
+            Text(this.roomNameText())
+              .fontSize(16)
+              .fontWeight(FontWeight.Bold)
+              .fontColor(this.contentTranslucentColor())
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+          } else {
+            Text('')
+              .fontSize(16)
+              .fontWeight(FontWeight.Bold)
+          }
+        }
+        .width('100%')
+        .alignItems(VerticalAlign.Center)
+
         ForEach([this.mediaTitleText()], (item: string) => {
           Text(item)
             .fontSize(16)
             .fontWeight(FontWeight.Bold)
-            .fontColor(this.primaryColor())
-            .opacity(0.88)
+            .fontColor(this.contentTranslucentColor())
             .maxLines(1)
             .textOverflow({ overflow: TextOverflow.Ellipsis })
             .transition(TransitionEffect.OPACITY.animation({
@@ -185,8 +205,7 @@ struct HarmonyMediaServiceCard {
           Text(item)
             .fontSize(12)
             .fontWeight(FontWeight.Medium)
-            .fontColor(this.secondaryColor())
-            .opacity(0.72)
+            .fontColor(this.contentTranslucentColor())
             .maxLines(1)
             .textOverflow({ overflow: TextOverflow.Ellipsis })
             .transition(TransitionEffect.OPACITY.animation({
@@ -221,8 +240,7 @@ struct HarmonyMediaServiceCard {
     Stack({ alignContent: Alignment.Center }) {
       SymbolGlyph(icon)
         .fontSize(action === 'play_pause' ? 26 : 23)
-        .fontColor([this.primaryColor()])
-        .opacity(action === 'play_pause' ? 0.92 : 0.72)
+        .fontColor([this.contentTranslucentColor()])
         .symbolEffect(new ReplaceSymbolEffect(EffectScope.WHOLE), true)
     }
     .width(ServiceCardUiConfig.controlButtonSize)
@@ -245,8 +263,7 @@ struct HarmonyMediaServiceCard {
       ForEach([this.playPauseIconKey()], (item: string) => {
         SymbolGlyph(item === 'pause' ? $r('sys.symbol.pause') : $r('sys.symbol.play_fill'))
           .fontSize(26)
-          .fontColor([this.primaryColor()])
-          .opacity(0.92)
+          .fontColor([this.contentTranslucentColor()])
           .symbolEffect(new ReplaceSymbolEffect(EffectScope.WHOLE), true)
       }, (item: string) => item)
     }
@@ -316,6 +333,10 @@ struct HarmonyMediaServiceCard {
     return this.title.trim().length > 0 ? this.title : Localization.t('state_unknown');
   }
 
+  private roomNameText(): string {
+    return this.areaName.trim();
+  }
+
   private subtitleText(): string {
     return this.subtitle.trim().length > 0 ? this.subtitle : Localization.t('state_unknown');
   }
@@ -328,8 +349,45 @@ struct HarmonyMediaServiceCard {
     return this.primaryTextColor.trim().length > 0 ? this.primaryTextColor : ServiceCardUiConfig.textPrimary;
   }
 
-  private secondaryColor(): string {
-    return this.secondaryTextColor.trim().length > 0 ? this.secondaryTextColor : ServiceCardUiConfig.textSecondary;
+  private contentTranslucentColor(): string {
+    return this.blendColor(this.primaryColor(), this.cardSurfaceColor(), 0.6);
+  }
+
+  private blendColor(foreground: string, background: string, foregroundRatio: number): string {
+    const fg = this.parseHexColor(foreground);
+    const bg = this.parseHexColor(background);
+    if (fg.length !== 3 || bg.length !== 3) {
+      return foreground.trim();
+    }
+    const ratio = Math.max(0, Math.min(1, foregroundRatio));
+    const red = Math.round(fg[0] * ratio + bg[0] * (1 - ratio));
+    const green = Math.round(fg[1] * ratio + bg[1] * (1 - ratio));
+    const blue = Math.round(fg[2] * ratio + bg[2] * (1 - ratio));
+    return `#${this.hexByte(red)}${this.hexByte(green)}${this.hexByte(blue)}`;
+  }
+
+  private parseHexColor(color: string): number[] {
+    const value = color.trim();
+    if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+      return [
+        Number.parseInt(value.substring(1, 3), 16),
+        Number.parseInt(value.substring(3, 5), 16),
+        Number.parseInt(value.substring(5, 7), 16)
+      ];
+    }
+    if (/^#[0-9a-fA-F]{8}$/.test(value)) {
+      return [
+        Number.parseInt(value.substring(3, 5), 16),
+        Number.parseInt(value.substring(5, 7), 16),
+        Number.parseInt(value.substring(7, 9), 16)
+      ];
+    }
+    return [];
+  }
+
+  private hexByte(value: number): string {
+    const normalized = Math.max(0, Math.min(255, value));
+    return normalized.toString(16).padStart(2, '0').toUpperCase();
   }
 
   private disabledColor(): string {


### PR DESCRIPTION
## Summary
- Add the media card area name above the track title using existing binding area data.
- Add a speaker symbol next to the area name and align its visual treatment with playback controls.
- Use one blended content color for media card text and playback symbols, and remove the now-unused secondary text color payload path.
