### PR TITLE
Add card entity detail launch

### DIFF
--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -2,6 +2,7 @@
 // It coordinates navigation, server selection, overlays, WebView state, and feature services.
 import common from '@ohos.app.ability.common';
 import web_webview from '@ohos.web.webview';
+import { hilog } from '@kit.PerformanceAnalysisKit';
 import { HaServerItem } from '../models/HaServerItem';
 import { UrlGuardResult } from '../models/UrlGuardResult';
 import { UrlService } from '../services/UrlService';
@@ -26,6 +27,7 @@ import { SensorRuntimeFlags } from '../features/sensors/SensorRuntimePresenter';
 import { SensorRuntimeService, SensorRuntimeSnapshot } from '../features/sensors/SensorRuntimeService';
 import { SensorRuntimeBridgeService } from '../features/sensors/SensorRuntimeBridgeService';
 import { CardFormService } from '../features/cards/CardFormService';
+import { CardEntityDetailLaunchService } from '../features/cards/CardEntityDetailLaunchService';
 import { MobileAppRegistrationService } from '../features/registration/MobileAppRegistrationService';
 import { RegistrationRuntimeService } from '../features/registration/RegistrationRuntimeService';
 import { DeviceProfileInfo } from '../shared/device/DeviceProfile';
@@ -33,6 +35,7 @@ import { Localization } from '../shared/i18n/Localization';
 import { StorageService, StoredServerInfo } from '../services/StorageService';
 import { DiscoveryCacheService } from '../services/DiscoveryCacheService';
 import { ManagedServer, ServerManager } from '../services/ServerManager';
+import { ServerInstanceStore, ServerRuntimeState } from '../services/ServerInstanceStore';
 import { ServerAuthRepository, ServerAuthSession } from '../services/ServerAuthRepository';
 import { AppSettingsStore } from '../services/AppSettingsStore';
 import { ExternalBusService } from '../services/ExternalBusService';
@@ -63,6 +66,9 @@ import { AppWindowRuntimeService } from './AppWindowRuntimeService';
 import { ServerOption } from '../features/settings/SettingsSectionRuntimeService';
 
 AppStorageDefaults.register();
+
+const DOMAIN = 0x0000;
+const TAG = 'HACompanion';
 
 function initialRuntimeRoute(): AppRoute {
   const baseUrl = AppStorage.get<string>('haBaseUrl') ?? '';
@@ -132,6 +138,9 @@ export struct AppRuntimeHost {
   @StorageLink('appForegroundTick') @Watch('onAppForegroundTick') appForegroundTick: number = 0;
   @StorageLink('appBackgroundTick') @Watch('onAppBackgroundTick') appBackgroundTick: number = 0;
   @StorageLink('appConfigTick') @Watch('onAppConfigurationTick') appConfigTick: number = 0;
+  @StorageLink('cardPendingEntityDetailEntityId') cardPendingEntityDetailEntityId: string = '';
+  @StorageLink('cardPendingEntityDetailServerInstanceId') cardPendingEntityDetailServerInstanceId: string = '';
+  @StorageLink('cardPendingEntityDetailTick') @Watch('onCardPendingEntityDetailTick') cardPendingEntityDetailTick: number = 0;
 
   @State @Watch('onStepChanged') step: number = initialRuntimeRoute();
   @State loading: boolean = false;
@@ -206,6 +215,10 @@ export struct AppRuntimeHost {
   @State companionChoiceDialogKey: string = '';
   @State assistStartListeningSignal: number = 0;
   @State assistStartListeningRequested: boolean = false;
+  private pendingEntityDetailEntityId: string = '';
+  private pendingEntityDetailRequestTick: number = 0;
+  private pendingEntityDetailScriptInFlight: boolean = false;
+  private entityDetailOpenedFromCard: boolean = false;
   discoveryAnimationToken: number = 0;
   discoveryAnimationRunning: boolean = false;
   discoverySheetPresented: boolean = false;
@@ -215,6 +228,7 @@ export struct AppRuntimeHost {
   private systemEventService: SystemEventService = new SystemEventService();
   private sensorRuntimeService: SensorRuntimeService = new SensorRuntimeService();
   private mobileAppRegistrationInFlight: boolean = false;
+  private pendingEntityDetailProcessingTick: number = 0;
 
   private webCtrl: web_webview.WebviewController = new web_webview.WebviewController();
   private externalAppProxy: ExternalAppProxy = new ExternalAppProxy(
@@ -471,6 +485,7 @@ export struct AppRuntimeHost {
       .catch((): void => {})
       .finally((): void => {
         AppLifecycleRuntimeService.aboutToAppear(this, AppRuntimeCallbackFactory.lifecycle(this));
+        this.openPendingEntityDetailFromCard();
       });
   }
 
@@ -632,6 +647,18 @@ export struct AppRuntimeHost {
     if (ExternalBusService.type(payload) === 'harmony_url_changed') {
       const url = ExternalBusService.stringPayload(payload, 'url', '');
       this.rememberDashboardUrl(url);
+      this.runPendingEntityDetailScript();
+      return;
+    }
+    if (ExternalBusService.type(payload) === 'harmony_card_entity_detail_ready') {
+      const entityId = ExternalBusService.stringPayload(payload, 'entityId', '');
+      if (entityId.length === 0 || entityId === this.pendingEntityDetailEntityId.trim()) {
+        this.runPendingEntityDetailScript();
+      }
+      return;
+    }
+    if (ExternalBusService.type(payload) === 'harmony_card_entity_detail_closed') {
+      this.entityDetailOpenedFromCard = false;
       return;
     }
     ExternalAuthRuntimeService.handleExternalBus(payload, this, AppRuntimeCallbackFactory.externalAuth(this));
@@ -728,7 +755,14 @@ export struct AppRuntimeHost {
     this.dashboardAuthProvided = false;
   }
 
-  handleBackNavigation(): boolean { return AppNavigationRuntimeService.handleBackNavigation(this, AppRuntimeCallbackFactory.navigation(this)); }
+  handleBackNavigation(): boolean {
+    if (this.shouldCloseCardEntityDetailBeforeDashboardBack()) {
+      this.entityDetailOpenedFromCard = false;
+      this.tryRunWebScript(CardEntityDetailLaunchService.closeMoreInfoScript());
+      return true;
+    }
+    return AppNavigationRuntimeService.handleBackNavigation(this, AppRuntimeCallbackFactory.navigation(this));
+  }
 
   onBackPress(): boolean { return this.handleBackNavigation(); }
 
@@ -778,6 +812,7 @@ export struct AppRuntimeHost {
 
   applyDashboardPreferences(): void {
     DashboardRuntimeService.applyDashboardPreferences(this.webCtrl, this);
+    this.runPendingEntityDetailScript();
   }
 
   refreshDashboardTheme(): void {
@@ -883,6 +918,263 @@ export struct AppRuntimeHost {
   private onAppBackgroundTick(): void { AppLifecycleRuntimeService.onBackground(this, AppRuntimeCallbackFactory.lifecycle(this)); }
 
   private onAppConfigurationTick(): void { AppLifecycleRuntimeService.onConfiguration(this, AppRuntimeCallbackFactory.lifecycle(this)); }
+
+  private onCardPendingEntityDetailTick(): void { this.openPendingEntityDetailFromCard(); }
+
+  private openPendingEntityDetailFromCard(): void {
+    const entityId = this.cardPendingEntityDetailEntityId.trim();
+    const tick = this.cardPendingEntityDetailTick;
+    if (tick <= 0 || this.pendingEntityDetailProcessingTick > 0 ||
+      !CardEntityDetailLaunchService.isValidEntityId(entityId)) {
+      return;
+    }
+    const serverInstanceId = this.cardPendingEntityDetailServerInstanceId.trim();
+    this.pendingEntityDetailProcessingTick = tick;
+    this.openEntityDetailFromCard(entityId, serverInstanceId, tick)
+      .then((): void => {
+        const isCurrent = this.isCurrentPendingEntityDetailRequest(entityId, serverInstanceId, tick);
+        this.pendingEntityDetailProcessingTick = 0;
+        if (!isCurrent) {
+          this.openPendingEntityDetailFromCard();
+          return;
+        }
+        this.cardPendingEntityDetailEntityId = '';
+        this.cardPendingEntityDetailServerInstanceId = '';
+        this.cardPendingEntityDetailTick = 0;
+      })
+      .catch((err: Error): void => {
+        const isCurrent = this.isCurrentPendingEntityDetailRequest(entityId, serverInstanceId, tick);
+        this.pendingEntityDetailProcessingTick = 0;
+        if (!isCurrent) {
+          this.openPendingEntityDetailFromCard();
+          return;
+        }
+        this.cardPendingEntityDetailEntityId = '';
+        this.cardPendingEntityDetailServerInstanceId = '';
+        this.cardPendingEntityDetailTick = 0;
+        this.message = this.stringifyError(err);
+      });
+  }
+
+  private isCurrentPendingEntityDetailRequest(entityId: string, serverInstanceId: string, tick: number): boolean {
+    return this.cardPendingEntityDetailTick === tick &&
+      this.cardPendingEntityDetailEntityId.trim() === entityId &&
+      this.cardPendingEntityDetailServerInstanceId.trim() === serverInstanceId.trim();
+  }
+
+  private isCurrentEntityDetailScriptRequest(entityId: string, tick: number): boolean {
+    return this.pendingEntityDetailRequestTick === tick &&
+      this.pendingEntityDetailEntityId.trim() === entityId;
+  }
+
+  private async openEntityDetailFromCard(entityId: string, serverInstanceId: string, tick: number): Promise<void> {
+    const context = this.context();
+    const activeServerId = ServerManager.getActiveServerIdSync(context);
+    let cardServerId = serverInstanceId.trim();
+    let baseUrl = this.haBaseUrl;
+    if (cardServerId.length > 0 && cardServerId !== activeServerId) {
+      const info = await this.activateServerForEntityDetail(cardServerId, entityId, serverInstanceId, tick);
+      if (!this.isCurrentPendingEntityDetailRequest(entityId, serverInstanceId, tick)) {
+        return;
+      }
+      baseUrl = info.baseUrl;
+    }
+    if (cardServerId.length === 0) {
+      cardServerId = activeServerId;
+    }
+    const resolvedBaseUrl = await this.resolveAllowedServerBaseUrl(cardServerId, baseUrl);
+    if (!this.isCurrentPendingEntityDetailRequest(entityId, serverInstanceId, tick)) {
+      return;
+    }
+    this.openEntityDetailDashboard(entityId, resolvedBaseUrl, tick);
+  }
+
+  private async activateServerForEntityDetail(
+    serverInstanceId: string,
+    entityId: string,
+    requestServerInstanceId: string,
+    tick: number
+  ): Promise<StoredServerInfo> {
+    const context = this.context();
+    await AppSettingsStore.saveCurrentAppStorage(context);
+    this.ensureCurrentPendingEntityDetailRequest(entityId, requestServerInstanceId, tick);
+    const record = await ServerInstanceStore.load(context, serverInstanceId);
+    this.ensureCurrentPendingEntityDetailRequest(entityId, requestServerInstanceId, tick);
+    if (!record || !StorageService.hasLogin(record.info)) {
+      throw new Error('missing server login');
+    }
+    const previousRuntime = await ServerInstanceStore.loadRuntime(context);
+    this.ensureCurrentPendingEntityDetailRequest(entityId, requestServerInstanceId, tick);
+    await this.commitActiveServerForEntityDetail(context, previousRuntime, record.id, record.info);
+    if (!this.isCurrentPendingEntityDetailRequest(entityId, requestServerInstanceId, tick)) {
+      await this.restoreServerRuntimeForEntityDetail(context, previousRuntime);
+      throw new Error('stale entity detail request');
+    }
+    await this.restoreInstanceAppSettingsState();
+    if (!this.isCurrentPendingEntityDetailRequest(entityId, requestServerInstanceId, tick)) {
+      await this.restoreServerRuntimeForEntityDetail(context, previousRuntime);
+      throw new Error('stale entity detail request');
+    }
+    AppSessionRuntimeService.applyServerInfoToState(this, record.info);
+    this.syncCardServerConnection();
+    this.configSummary = Localization.t('common_not_set');
+    this.applyThemePreferences();
+    this.applyWindowPreferences();
+    this.resetSensorRuntime();
+    this.syncPublicSensors('server_switched');
+    this.selectedServerSettingsId = serverInstanceId;
+    this.selectedServerSettingsInfo = record.info;
+    this.selectedServerSettingsName = SettingsSummaryService.serverDisplayName('', record.info.baseUrl);
+    this.selectedServerSettingsActive = true;
+    this.refreshServerOptions();
+    this.fetchHaConfig().catch((): void => {});
+    return record.info;
+  }
+
+  private ensureCurrentPendingEntityDetailRequest(entityId: string, serverInstanceId: string, tick: number): void {
+    if (!this.isCurrentPendingEntityDetailRequest(entityId, serverInstanceId, tick)) {
+      throw new Error('stale entity detail request');
+    }
+  }
+
+  private async commitActiveServerForEntityDetail(
+    context: common.Context,
+    previousRuntime: ServerRuntimeState,
+    serverInstanceId: string,
+    info: StoredServerInfo
+  ): Promise<void> {
+    const runtime: ServerRuntimeState = {
+      activeServerId: serverInstanceId,
+      serverOrder: previousRuntime.serverOrder.slice()
+    };
+    if (!runtime.serverOrder.includes(serverInstanceId)) {
+      runtime.serverOrder.push(serverInstanceId);
+    }
+    await ServerInstanceStore.saveRuntime(context, runtime);
+    ServerManager.applyActiveToAppStorage(info);
+  }
+
+  private async restoreServerRuntimeForEntityDetail(
+    context: common.Context,
+    runtime: ServerRuntimeState
+  ): Promise<void> {
+    await ServerInstanceStore.saveRuntime(context, runtime);
+    const info = runtime.activeServerId.length > 0 ?
+      ServerManager.getServerInfoSync(context, runtime.activeServerId) :
+      StorageService.emptyServerInfo();
+    ServerManager.applyActiveToAppStorage(info);
+    await this.restoreInstanceAppSettingsState();
+  }
+
+  private openEntityDetailDashboard(entityId: string, baseUrl: string, tick: number): void {
+    const normalizedBaseUrl = UrlService.normalizeBaseUrl(baseUrl);
+    if (normalizedBaseUrl.length === 0) {
+      return;
+    }
+    this.pendingEntityDetailEntityId = entityId;
+    this.pendingEntityDetailRequestTick = tick;
+    this.pendingEntityDetailScriptInFlight = false;
+    this.entityDetailOpenedFromCard = false;
+    if (this.canOpenEntityDetailInCurrentDashboard(normalizedBaseUrl)) {
+      this.step = AppRoute.DASHBOARD;
+      this.runPendingEntityDetailScript();
+      return;
+    }
+    const dashboardUrl = UrlService.buildDashboardUrl(normalizedBaseUrl);
+    if (this.shouldNavigateCurrentHaPageToDashboardForEntityDetail(normalizedBaseUrl)) {
+      this.openDashboard();
+      this.dashboardUrl = dashboardUrl;
+      this.dashboardCurrentUrl = dashboardUrl;
+      this.tryRunWebScript(CardEntityDetailLaunchService.navigateToDashboardScript(dashboardUrl), (raw): void => {
+        if (!this.isCurrentEntityDetailScriptRequest(entityId, tick)) {
+          return;
+        }
+        const result = String(raw);
+        if (result === 'true' || result === '"true"') {
+          this.runPendingEntityDetailScript();
+          return;
+        }
+        this.dashboardLoadedUrl = '';
+        this.dashboardBridgeReady = false;
+        this.dashboardAuthProvided = false;
+        this.forceLoadDashboard(dashboardUrl);
+      });
+      return;
+    }
+    this.openDashboard();
+    this.dashboardUrl = dashboardUrl;
+    this.dashboardLoadedUrl = '';
+    this.dashboardCurrentUrl = dashboardUrl;
+    this.dashboardBridgeReady = false;
+    this.dashboardAuthProvided = false;
+    this.forceLoadDashboard(dashboardUrl);
+  }
+
+  private canOpenEntityDetailInCurrentDashboard(baseUrl: string): boolean {
+    if (!this.isWebControllerMounted() || this.dashboardInsecureBlocked) {
+      return false;
+    }
+    const currentUrl = this.currentDashboardUrl();
+    if (!UrlService.isHttpLikeUrl(currentUrl)) {
+      return false;
+    }
+    if (!this.isLovelaceDashboardPage(currentUrl)) {
+      return false;
+    }
+    return UrlService.endpointKey(currentUrl) === UrlService.endpointKey(baseUrl);
+  }
+
+  private shouldNavigateCurrentHaPageToDashboardForEntityDetail(baseUrl: string): boolean {
+    if (!this.isWebControllerMounted() || this.dashboardInsecureBlocked) {
+      return false;
+    }
+    const currentUrl = this.currentDashboardUrl();
+    if (!UrlService.isHttpLikeUrl(currentUrl) || this.isLovelaceDashboardPage(currentUrl)) {
+      return false;
+    }
+    return UrlService.endpointKey(currentUrl) === UrlService.endpointKey(baseUrl);
+  }
+
+  private isLovelaceDashboardPage(url: string): boolean {
+    const path = UrlService.urlPathOnly(url);
+    return path === '/' || path === '/lovelace' || path.startsWith('/lovelace/');
+  }
+
+  private runPendingEntityDetailScript(): void {
+    const entityId = this.pendingEntityDetailEntityId.trim();
+    const requestTick = this.pendingEntityDetailRequestTick;
+    if (!CardEntityDetailLaunchService.isValidEntityId(entityId)) {
+      return;
+    }
+    if (this.pendingEntityDetailScriptInFlight) {
+      return;
+    }
+    this.pendingEntityDetailScriptInFlight = true;
+    this.tryRunWebScript(CardEntityDetailLaunchService.moreInfoScript(entityId), (raw): void => {
+      this.pendingEntityDetailScriptInFlight = false;
+      if (!this.isCurrentEntityDetailScriptRequest(entityId, requestTick)) {
+        this.runPendingEntityDetailScript();
+        return;
+      }
+      const result = String(raw);
+      if (result === 'opened' || result === '"opened"' || result === 'true' || result === '"true"') {
+        this.pendingEntityDetailEntityId = '';
+        this.pendingEntityDetailRequestTick = 0;
+        this.entityDetailOpenedFromCard = true;
+        return;
+      }
+      if (result === 'missing_entity' || result === '"missing_entity"') {
+        this.pendingEntityDetailEntityId = '';
+        this.pendingEntityDetailRequestTick = 0;
+        this.entityDetailOpenedFromCard = false;
+        hilog.warn(DOMAIN, TAG, 'Pending entity detail target is missing. entity=%{public}s', entityId);
+      }
+    });
+  }
+
+  private shouldCloseCardEntityDetailBeforeDashboardBack(): boolean {
+    return this.entityDetailOpenedFromCard && this.step === AppRoute.DASHBOARD;
+  }
 
   currentStoredServerInfo(): StoredServerInfo { return AppSessionRuntimeService.currentStoredServerInfo(this); }
 

--- a/entry/src/main/ets/app/AppStorageDefaults.ets
+++ b/entry/src/main/ets/app/AppStorageDefaults.ets
@@ -65,5 +65,8 @@ export class AppStorageDefaults {
     AppStorage.setOrCreate<string>('gestureSwipeDownThreeAction', AppStorage.get<string>('gestureSwipeDownThreeAction') ?? 'none');
     AppStorage.setOrCreate<string>('assistAgentId', AppStorage.get<string>('assistAgentId') ?? '');
     AppStorage.setOrCreate<string>('cardEditCardType', AppStorage.get<string>('cardEditCardType') ?? '');
+    AppStorage.setOrCreate<string>('cardPendingEntityDetailEntityId', AppStorage.get<string>('cardPendingEntityDetailEntityId') ?? '');
+    AppStorage.setOrCreate<string>('cardPendingEntityDetailServerInstanceId', AppStorage.get<string>('cardPendingEntityDetailServerInstanceId') ?? '');
+    AppStorage.setOrCreate<number>('cardPendingEntityDetailTick', AppStorage.get<number>('cardPendingEntityDetailTick') ?? 0);
   }
 }

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -11,6 +11,7 @@ import { AppSettingsStore } from '../services/AppSettingsStore';
 import { DiscoveryCacheService } from '../services/DiscoveryCacheService';
 import { HARMONY_GEOFENCE_ACTION } from '../services/HarmonyLocationService';
 import { ServerManager } from '../services/ServerManager';
+import { CardEntityDetailLaunchService } from '../features/cards/CardEntityDetailLaunchService';
 
 const DOMAIN = 0x0000;
 const TAG = 'HACompanion';
@@ -21,6 +22,7 @@ export default class EntryAbility extends UIAbility {
   onCreate(want: Want, launchParam: AbilityConstant.LaunchParam): void {
     AppStorageDefaults.register();
     this.handleLocationWant(want);
+    this.handleEntityDetailWant(want);
     LongRunningTaskService.setRecoveryHandler((context): void => {
       if ((AppStorage.get<string>('websocketMode') ?? 'system') !== 'always') {
         return;
@@ -38,6 +40,7 @@ export default class EntryAbility extends UIAbility {
 
   onNewWant(want: Want, _launchParam: AbilityConstant.LaunchParam): void {
     this.handleLocationWant(want);
+    this.handleEntityDetailWant(want);
   }
 
   onDestroy(): void {
@@ -160,6 +163,15 @@ export default class EntryAbility extends UIAbility {
       .catch((err: Error): void => {
         hilog.warn(DOMAIN, TAG, 'Failed to handle geofence want. Cause: %{public}s', err.message);
       });
+  }
+
+  private handleEntityDetailWant(want: Want): void {
+    const request = CardEntityDetailLaunchService.requestFromWant(want);
+    if (!request) {
+      return;
+    }
+    CardEntityDetailLaunchService.publishPending(request);
+    AppStorage.setOrCreate<number>('appForegroundTick', Date.now());
   }
 
   private saveCurrentAppStorageIfRestored(): void {

--- a/entry/src/main/ets/features/cards/CardEntityDetailLaunchService.ets
+++ b/entry/src/main/ets/features/cards/CardEntityDetailLaunchService.ets
@@ -1,0 +1,229 @@
+import { Want } from '@kit.AbilityKit';
+
+export interface CardEntityDetailRequest {
+  entityId: string;
+  serverInstanceId: string;
+}
+
+export class CardEntityDetailLaunchService {
+  static readonly ACTION: string = 'ha.open_entity_detail';
+  static readonly ENTITY_ID_PARAM: string = 'entityId';
+  static readonly SERVER_INSTANCE_ID_PARAM: string = 'serverInstanceId';
+  static readonly PENDING_ENTITY_ID_KEY: string = 'cardPendingEntityDetailEntityId';
+  static readonly PENDING_SERVER_ID_KEY: string = 'cardPendingEntityDetailServerInstanceId';
+  static readonly PENDING_TICK_KEY: string = 'cardPendingEntityDetailTick';
+
+  static requestFromWant(want: Want): CardEntityDetailRequest | undefined {
+    const params = want.parameters;
+    if (!params) {
+      return undefined;
+    }
+    if (CardEntityDetailLaunchService.stringParam(params, 'action') !== CardEntityDetailLaunchService.ACTION) {
+      return undefined;
+    }
+    const entityId = CardEntityDetailLaunchService.stringParam(params, CardEntityDetailLaunchService.ENTITY_ID_PARAM);
+    if (!CardEntityDetailLaunchService.isValidEntityId(entityId)) {
+      return undefined;
+    }
+    return {
+      entityId,
+      serverInstanceId: CardEntityDetailLaunchService.stringParam(params, CardEntityDetailLaunchService.SERVER_INSTANCE_ID_PARAM)
+    };
+  }
+
+  static publishPending(request: CardEntityDetailRequest): void {
+    AppStorage.setOrCreate<string>(CardEntityDetailLaunchService.PENDING_ENTITY_ID_KEY, request.entityId);
+    AppStorage.setOrCreate<string>(CardEntityDetailLaunchService.PENDING_SERVER_ID_KEY, request.serverInstanceId);
+    const currentTick = AppStorage.get<number>(CardEntityDetailLaunchService.PENDING_TICK_KEY) ?? 0;
+    AppStorage.setOrCreate<number>(CardEntityDetailLaunchService.PENDING_TICK_KEY, currentTick + 1);
+  }
+
+  static isValidEntityId(entityId: string): boolean {
+    const value = entityId.trim();
+    const dot = value.indexOf('.');
+    if (dot <= 0 || dot !== value.lastIndexOf('.') || dot >= value.length - 1) {
+      return false;
+    }
+    return CardEntityDetailLaunchService.isValidEntityPart(value.substring(0, dot)) &&
+      CardEntityDetailLaunchService.isValidEntityPart(value.substring(dot + 1));
+  }
+
+  static moreInfoScript(entityId: string): string {
+    const encoded = JSON.stringify(entityId);
+    return `(function(){` +
+      `var entityId=${encoded};` +
+      `function q(root,selector){return root&&typeof root.querySelector==='function'?root.querySelector(selector):null;}` +
+      `function isUpdated(el){return el&&el.hasUpdated!==false;}` +
+      `function notifyClosed(){` +
+      `if(window.__haHarmonyCardMoreInfoClosedNotified){return;}` +
+      `window.__haHarmonyCardMoreInfoClosedNotified=true;` +
+      `try{externalApp.externalBus(JSON.stringify({type:'harmony_card_entity_detail_closed',payload:{entityId:entityId}}));}catch(e){}` +
+      `}` +
+      `function isDialogOpen(ha){` +
+      `if(history.state&&history.state.dialog==='ha-more-info-dialog'){return true;}` +
+      `var dialog=ha&&ha.shadowRoot?q(ha.shadowRoot,'ha-more-info-dialog'):null;` +
+      `if(!dialog){return false;}` +
+      `if(dialog.open===true||dialog.opened===true||(dialog.hasAttribute&&dialog.hasAttribute('open'))){return true;}` +
+      `var inner=q(dialog.shadowRoot,'ha-dialog,mwc-dialog');` +
+      `return !!(inner&&(inner.open===true||inner.opened===true||(inner.hasAttribute&&inner.hasAttribute('open'))));` +
+      `}` +
+      `function installCloseWatcher(ha){` +
+      `window.__haHarmonyCardMoreInfoClosedNotified=false;` +
+      `window.__haHarmonyCardMoreInfoSeenOpen=false;` +
+      `function check(){` +
+      `var open=isDialogOpen(ha);` +
+      `if(open){window.__haHarmonyCardMoreInfoSeenOpen=true;return;}` +
+      `if(window.__haHarmonyCardMoreInfoSeenOpen){notifyClosed();}` +
+      `}` +
+      `window.__haHarmonyCardMoreInfoCheck=check;` +
+      `function schedule(){Promise.resolve().then(function(){var fn=window.__haHarmonyCardMoreInfoCheck;if(typeof fn==='function'){fn();}});}` +
+      `if(!window.__haHarmonyCardMoreInfoWatcherInstalled){` +
+      `window.__haHarmonyCardMoreInfoWatcherInstalled=true;` +
+      `window.addEventListener('popstate',schedule,true);` +
+      `window.addEventListener('hashchange',schedule,true);` +
+      `window.addEventListener('location-changed',schedule,true);` +
+      `window.addEventListener('close-dialog',schedule,true);` +
+      `window.addEventListener('dialog-closed',schedule,true);` +
+      `window.__haHarmonyCardMoreInfoObserver=new MutationObserver(schedule);` +
+      `}` +
+      `try{` +
+      `var observer=window.__haHarmonyCardMoreInfoObserver;` +
+      `if(observer){observer.disconnect();observer.observe(ha.shadowRoot||document,{childList:true,subtree:true,attributes:true,attributeFilter:['open','aria-hidden']});}` +
+      `}catch(e){}` +
+      `schedule();` +
+      `}` +
+      `function hasRenderedViewContent(layout){` +
+      `var name=String(layout.localName||'');` +
+      `var root=layout.shadowRoot||layout;` +
+      `var cardCount=layout.cards&&layout.cards.length?layout.cards.length:0;` +
+      `var sectionCount=layout.sections&&layout.sections.length?layout.sections.length:0;` +
+      `if((name==='hui-masonry-view'||name==='hui-panel-view'||name==='hui-sidebar-view')&&cardCount>0&&!q(root,'hui-card,hui-card-options')){return false;}` +
+      `if(name==='hui-sections-view'&&sectionCount>0&&!q(root,'hui-section')){return false;}` +
+      `return true;` +
+      `}` +
+      `function readiness(ha){` +
+      `if(!ha){return 'pending';}` +
+      `if(!ha.hass||!ha.hass.states||!ha.shadowRoot||!isUpdated(ha)){return 'pending';}` +
+      `if(!ha.hass.states[entityId]){return 'missing_entity';}` +
+      `var main=q(ha.shadowRoot,'home-assistant-main');` +
+      `if(!main||!main.shadowRoot||!isUpdated(main)){return 'pending';}` +
+      `var resolver=q(main.shadowRoot,'partial-panel-resolver');` +
+      `if(!resolver||!isUpdated(resolver)){return 'pending';}` +
+      `var panel=q(resolver,'ha-panel-lovelace');` +
+      `if(!panel||!panel.shadowRoot||!isUpdated(panel)){return 'pending';}` +
+      `var root=q(panel.shadowRoot,'hui-root');` +
+      `if(!root||!root.shadowRoot||!isUpdated(root)){return 'pending';}` +
+      `var viewContainer=q(root.shadowRoot,'hui-view-container#view');` +
+      `if(!viewContainer||!isUpdated(viewContainer)){return 'pending';}` +
+      `var view=q(viewContainer,'hui-view');` +
+      `if(!view||!isUpdated(view)){return 'pending';}` +
+      `var layout=view.firstElementChild;` +
+      `if(!layout||!isUpdated(layout)||!hasRenderedViewContent(layout)){return 'pending';}` +
+      `return 'ready';` +
+      `}` +
+      `function clearReadyWatcher(){` +
+      `try{` +
+      `var observer=window.__haHarmonyCardMoreInfoReadyObserver;` +
+      `if(observer){observer.disconnect();}` +
+      `window.__haHarmonyCardMoreInfoReadyCheck=null;` +
+      `}catch(e){}` +
+      `}` +
+      `function notifyReady(){` +
+      `if(window.__haHarmonyCardMoreInfoReadyNotified){return;}` +
+      `window.__haHarmonyCardMoreInfoReadyNotified=true;` +
+      `clearReadyWatcher();` +
+      `try{externalApp.externalBus(JSON.stringify({type:'harmony_card_entity_detail_ready',payload:{entityId:entityId}}));}catch(e){}` +
+      `}` +
+      `function installReadyWatcher(){` +
+      `window.__haHarmonyCardMoreInfoReadyNotified=false;` +
+      `function observeReadyRoots(){` +
+      `try{` +
+      `var observer=window.__haHarmonyCardMoreInfoReadyObserver;` +
+      `if(!observer){return;}` +
+      `function observe(root){if(root){observer.observe(root,{childList:true,subtree:true,attributes:true});}}` +
+      `var ha=document.querySelector('home-assistant');` +
+      `observe(document.documentElement);` +
+      `if(ha){observe(ha.shadowRoot);}` +
+      `var main=ha&&ha.shadowRoot?q(ha.shadowRoot,'home-assistant-main'):null;` +
+      `if(main){observe(main.shadowRoot);}` +
+      `var resolver=main&&main.shadowRoot?q(main.shadowRoot,'partial-panel-resolver'):null;` +
+      `var panel=resolver?q(resolver,'ha-panel-lovelace'):null;` +
+      `if(panel){observe(panel.shadowRoot);}` +
+      `var root=panel&&panel.shadowRoot?q(panel.shadowRoot,'hui-root'):null;` +
+      `if(root){observe(root.shadowRoot);}` +
+      `}catch(e){}` +
+      `}` +
+      `function checkReady(){` +
+      `observeReadyRoots();` +
+      `var state=readiness(document.querySelector('home-assistant'));` +
+      `if(state==='ready'||state==='missing_entity'){notifyReady();}` +
+      `}` +
+      `window.__haHarmonyCardMoreInfoReadyCheck=checkReady;` +
+      `function scheduleReady(){Promise.resolve().then(function(){var fn=window.__haHarmonyCardMoreInfoReadyCheck;if(typeof fn==='function'){fn();}});}` +
+      `if(!window.__haHarmonyCardMoreInfoReadyWatcherInstalled){` +
+      `window.__haHarmonyCardMoreInfoReadyWatcherInstalled=true;` +
+      `window.addEventListener('location-changed',scheduleReady,true);` +
+      `window.addEventListener('popstate',scheduleReady,true);` +
+      `window.addEventListener('hashchange',scheduleReady,true);` +
+      `window.__haHarmonyCardMoreInfoReadyObserver=new MutationObserver(scheduleReady);` +
+      `}` +
+      `scheduleReady();` +
+      `}` +
+      `var ha=document.querySelector('home-assistant');` +
+      `var state=readiness(ha);` +
+      `if(state==='missing_entity'){return 'missing_entity';}` +
+      `if(state!=='ready'){installReadyWatcher();return 'pending';}` +
+      `installCloseWatcher(ha);` +
+      `ha.dispatchEvent(new CustomEvent('hass-more-info',{detail:{entityId:entityId},bubbles:true,composed:true}));` +
+      `var check=window.__haHarmonyCardMoreInfoCheck;if(typeof check==='function'){Promise.resolve().then(check);}` +
+      `return 'opened';` +
+      `})();`;
+  }
+
+  static closeMoreInfoScript(): string {
+    return `(function(){` +
+      `var ha=document.querySelector('home-assistant');` +
+      `var dialog=ha&&ha.shadowRoot?ha.shadowRoot.querySelector('ha-more-info-dialog'):null;` +
+      `if(dialog){dialog.dispatchEvent(new CustomEvent('close-dialog',{bubbles:true,composed:true}));return true;}` +
+      `if(history.state&&history.state.dialog==='ha-more-info-dialog'){history.back();return true;}` +
+      `return false;` +
+      `})();`;
+  }
+
+  static navigateToDashboardScript(dashboardUrl: string): string {
+    const encoded = JSON.stringify(dashboardUrl);
+    return `(function(){` +
+      `var target=${encoded};` +
+      `if(!target){return false;}` +
+      `try{` +
+      `var url=new URL(target,location.href);` +
+      `if(url.origin!==location.origin){return false;}` +
+      `var path=url.pathname+url.search+url.hash;` +
+      `if((location.pathname+location.search+location.hash)===path){return true;}` +
+      `history.replaceState(history.state,'',path);` +
+      `window.dispatchEvent(new CustomEvent('location-changed',{detail:{replace:true}}));` +
+      `return true;` +
+      `}catch(e){return false;}` +
+      `})();`;
+  }
+
+  private static stringParam(params: Record<string, Object>, key: string): string {
+    const value = params[key];
+    return typeof value === 'string' ? value.trim() : '';
+  }
+
+  private static isValidEntityPart(value: string): boolean {
+    if (value.length === 0 || value.startsWith('_') || value.endsWith('_') || value.indexOf('__') >= 0) {
+      return false;
+    }
+    for (let i = 0; i < value.length; i++) {
+      const code = value.charCodeAt(i);
+      const isDigit = code >= 48 && code <= 57;
+      const isLower = code >= 97 && code <= 122;
+      if (!isDigit && !isLower && value[i] !== '_') {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/entry/src/main/ets/features/cards/CardRuntimeCoordinator.ets
+++ b/entry/src/main/ets/features/cards/CardRuntimeCoordinator.ets
@@ -17,6 +17,9 @@ import { CardMediaCacheStore } from './CardMediaCacheStore';
 interface LightFormData {
   formId: string;
   bound: boolean;
+  targetId: string;
+  serverInstanceId: string;
+  openEntityDetailEnabled: boolean;
   title: string;
   subtitle: string;
   state: string;
@@ -26,6 +29,9 @@ interface LightFormData {
 interface SceneFormData {
   formId: string;
   bound: boolean;
+  targetId: string;
+  serverInstanceId: string;
+  openEntityDetailEnabled: boolean;
   title: string;
   subtitle: string;
   state: string;
@@ -35,6 +41,9 @@ interface SceneFormData {
 interface MediaFormData {
   formId: string;
   bound: boolean;
+  targetId: string;
+  serverInstanceId: string;
+  openEntityDetailEnabled: boolean;
   title: string;
   subtitle: string;
   state: string;
@@ -296,6 +305,9 @@ export class CardRuntimeCoordinator {
     return {
       formId,
       bound,
+      targetId: bound ? record.targetId : '',
+      serverInstanceId: bound ? record.serverInstanceId : '',
+      openEntityDetailEnabled: bound,
       title: bound ? record.targetName : Localization.t('card_light_control_title'),
       subtitle: bound ? CardRuntimeCoordinator.lightSubtitle(record) : Localization.t('card_bind_light_device'),
       state: bound ? record.state : 'unknown',
@@ -308,6 +320,9 @@ export class CardRuntimeCoordinator {
     return {
       formId,
       bound,
+      targetId: bound ? record.targetId : '',
+      serverInstanceId: bound ? record.serverInstanceId : '',
+      openEntityDetailEnabled: false,
       title: bound ? record.targetName : Localization.t('card_scene_control_title'),
       subtitle: bound ? CardRuntimeCoordinator.sceneFeedbackText(record.state) : Localization.t('card_bind_scene'),
       state: bound ? record.state : 'unknown',
@@ -321,6 +336,9 @@ export class CardRuntimeCoordinator {
     const data: MediaFormData = {
       formId,
       bound,
+      targetId: bound ? record.targetId : '',
+      serverInstanceId: bound ? record.serverInstanceId : '',
+      openEntityDetailEnabled: bound,
       title: bound ? record.targetName : Localization.t('card_media_control_title'),
       subtitle: bound ? CardRuntimeCoordinator.mediaSubtitle(record, display) : Localization.t('card_bind_media_player'),
       state: bound ? record.state : 'unknown',

--- a/entry/src/main/ets/features/dashboard/DashboardWebControllerTools.ets
+++ b/entry/src/main/ets/features/dashboard/DashboardWebControllerTools.ets
@@ -11,12 +11,17 @@ export class DashboardWebControllerTools {
       if (onResolve) {
         promise.then((raw: Object | string | number | ArrayBuffer): void => {
           onResolve(raw);
-        }).catch((): void => {});
+        }).catch((): void => {
+          onResolve('false');
+        });
       } else {
         promise.catch((): void => {});
       }
     } catch (_) {
       // Ignore while the WebView is not attached yet.
+      if (onResolve) {
+        onResolve('false');
+      }
     }
   }
 

--- a/entry/src/main/ets/services/UrlService.ets
+++ b/entry/src/main/ets/services/UrlService.ets
@@ -158,6 +158,6 @@ export class UrlService {
 
   static isDashboardHomeUrl(url: string): boolean {
     const path = UrlService.urlPathOnly(url);
-    return path === '/' || path === '/lovelace' || path === '/lovelace/default_view';
+    return path === '/' || path === '/lovelace' || path === '/lovelace/home' || path === '/lovelace/default_view';
   }
 }

--- a/entry/src/main/ets/widget/pages/HarmonyLightServiceCard.ets
+++ b/entry/src/main/ets/widget/pages/HarmonyLightServiceCard.ets
@@ -1,4 +1,5 @@
 import { Localization } from '../../shared/i18n/Localization';
+import { CardEntityDetailLaunchService } from '../../features/cards/CardEntityDetailLaunchService';
 import { CardRefreshTicker } from '../components/CardRefreshTicker';
 import { ServiceCardUiConfig } from '../components/ServiceCardUiConfig';
 
@@ -9,6 +10,9 @@ let harmonyLightServiceCardStorage = new LocalStorage();
 struct HarmonyLightServiceCard {
   @LocalStorageProp('formId') formId: string = '';
   @LocalStorageProp('bound') bound: boolean = false;
+  @LocalStorageProp('targetId') targetId: string = '';
+  @LocalStorageProp('serverInstanceId') serverInstanceId: string = '';
+  @LocalStorageProp('openEntityDetailEnabled') openEntityDetailEnabled: boolean = false;
   @LocalStorageProp('title') title: string = Localization.t('card_light_control_title');
   @LocalStorageProp('subtitle') subtitle: string = Localization.t('card_bind_light_device');
   @LocalStorageProp('state') state: string = 'unknown';
@@ -20,16 +24,9 @@ struct HarmonyLightServiceCard {
 
       Column() {
         if (this.bound) {
-          this.boundHeader()
+          this.boundContent()
         } else {
           this.unboundContent()
-        }
-
-        Blank()
-          .layoutWeight(1)
-
-        if (this.bound) {
-          this.powerButton()
         }
       }
       .width('100%')
@@ -42,6 +39,27 @@ struct HarmonyLightServiceCard {
     }
     .width('100%')
     .height('100%')
+  }
+
+  @Builder
+  private boundContent(): void {
+    Column() {
+      Column() {
+        this.boundHeader()
+
+        Blank()
+          .layoutWeight(1)
+      }
+      .width('100%')
+      .layoutWeight(1)
+      .alignItems(HorizontalAlign.Start)
+      .onClick(() => this.openEntityDetail())
+
+      this.powerButton()
+    }
+    .width('100%')
+    .height('100%')
+    .alignItems(HorizontalAlign.Start)
   }
 
   @Builder
@@ -132,6 +150,8 @@ struct HarmonyLightServiceCard {
     Row() {
       Blank()
         .layoutWeight(1)
+        .height(ServiceCardUiConfig.iconButtonSize)
+        .onClick(() => this.openEntityDetail())
 
       Stack({ alignContent: Alignment.Center }) {
         SymbolGlyph($r('sys.symbol.power'))
@@ -162,6 +182,22 @@ struct HarmonyLightServiceCard {
 
   private displaySubtitle(): string {
     return this.subtitle.trim().length > 0 ? this.subtitle : Localization.t('state_unknown');
+  }
+
+  private openEntityDetail(): void {
+    if (!this.bound || !this.openEntityDetailEnabled || this.targetId.trim().length === 0) {
+      return;
+    }
+    postCardAction(this, {
+      action: 'router',
+      abilityName: 'EntryAbility',
+      params: {
+        action: CardEntityDetailLaunchService.ACTION,
+        entityId: this.targetId,
+        serverInstanceId: this.serverInstanceId,
+        formId: this.formId
+      }
+    });
   }
 
   private isOn(): boolean {

--- a/entry/src/main/ets/widget/pages/HarmonyMediaServiceCard.ets
+++ b/entry/src/main/ets/widget/pages/HarmonyMediaServiceCard.ets
@@ -1,4 +1,5 @@
 import { Localization } from '../../shared/i18n/Localization';
+import { CardEntityDetailLaunchService } from '../../features/cards/CardEntityDetailLaunchService';
 import { CardRefreshTicker } from '../components/CardRefreshTicker';
 import { ServiceCardUiConfig } from '../components/ServiceCardUiConfig';
 
@@ -9,6 +10,9 @@ let harmonyMediaServiceCardStorage = new LocalStorage();
 struct HarmonyMediaServiceCard {
   @LocalStorageProp('formId') formId: string = '';
   @LocalStorageProp('bound') bound: boolean = false;
+  @LocalStorageProp('targetId') targetId: string = '';
+  @LocalStorageProp('serverInstanceId') serverInstanceId: string = '';
+  @LocalStorageProp('openEntityDetailEnabled') openEntityDetailEnabled: boolean = false;
   @LocalStorageProp('title') title: string = Localization.t('card_media_control_title');
   @LocalStorageProp('subtitle') subtitle: string = Localization.t('card_bind_media_player');
   @LocalStorageProp('state') state: string = 'unknown';
@@ -144,6 +148,7 @@ struct HarmonyMediaServiceCard {
     }
     .width('100%')
     .height('100%')
+    .onClick(() => this.openEntityDetail())
   }
 
   @Builder
@@ -165,6 +170,32 @@ struct HarmonyMediaServiceCard {
 
   @Builder
   private contentArea(): void {
+    Column() {
+      this.detailContentArea()
+
+      Row() {
+        this.controlButton('previous', $r('sys.symbol.backward_end_fill'))
+        this.controlGap()
+        this.playPauseButton()
+        this.controlGap()
+        this.controlButton('next', $r('sys.symbol.forward_end_fill'))
+        Blank()
+          .layoutWeight(1)
+          .height(ServiceCardUiConfig.controlButtonSize)
+          .onClick(() => this.openEntityDetail())
+      }
+      .width('100%')
+      .alignItems(VerticalAlign.Center)
+      .justifyContent(FlexAlign.Start)
+    }
+    .width('58%')
+    .height('100%')
+    .padding({ left: 12, right: 12, top: 12, bottom: 12 })
+    .alignItems(HorizontalAlign.Start)
+  }
+
+  @Builder
+  private detailContentArea(): void {
     Column() {
       Column({ space: 3 }) {
         ForEach([this.mediaTitleText()], (item: string) => {
@@ -200,20 +231,19 @@ struct HarmonyMediaServiceCard {
 
       Blank()
         .layoutWeight(1)
-
-      Row({ space: 12 }) {
-        this.controlButton('previous', $r('sys.symbol.backward_end_fill'))
-        this.playPauseButton()
-        this.controlButton('next', $r('sys.symbol.forward_end_fill'))
-      }
-      .width('100%')
-      .alignItems(VerticalAlign.Center)
-      .justifyContent(FlexAlign.Start)
     }
-    .width('58%')
-    .height('100%')
-    .padding({ left: 12, right: 12, top: 12, bottom: 12 })
+    .width('100%')
+    .layoutWeight(1)
     .alignItems(HorizontalAlign.Start)
+    .onClick(() => this.openEntityDetail())
+  }
+
+  @Builder
+  private controlGap(): void {
+    Blank()
+      .width(12)
+      .height(ServiceCardUiConfig.controlButtonSize)
+      .onClick(() => this.openEntityDetail())
   }
 
   @Builder
@@ -274,6 +304,22 @@ struct HarmonyMediaServiceCard {
         cardType: 'media'
       }
       });
+  }
+
+  private openEntityDetail(): void {
+    if (!this.bound || !this.openEntityDetailEnabled || this.targetId.trim().length === 0) {
+      return;
+    }
+    postCardAction(this, {
+      action: 'router',
+      abilityName: 'EntryAbility',
+      params: {
+        action: CardEntityDetailLaunchService.ACTION,
+        entityId: this.targetId,
+        serverInstanceId: this.serverInstanceId,
+        formId: this.formId
+      }
+    });
   }
 
   private coverSource(): string | Resource {

--- a/entry/src/main/ets/widget/pages/HarmonySceneServiceCard.ets
+++ b/entry/src/main/ets/widget/pages/HarmonySceneServiceCard.ets
@@ -1,4 +1,5 @@
 import { Localization } from '../../shared/i18n/Localization';
+import { CardEntityDetailLaunchService } from '../../features/cards/CardEntityDetailLaunchService';
 import { CardRefreshTicker } from '../components/CardRefreshTicker';
 import { ServiceCardUiConfig } from '../components/ServiceCardUiConfig';
 
@@ -9,6 +10,9 @@ let harmonySceneServiceCardStorage = new LocalStorage();
 struct HarmonySceneServiceCard {
   @LocalStorageProp('formId') formId: string = '';
   @LocalStorageProp('bound') bound: boolean = false;
+  @LocalStorageProp('targetId') targetId: string = '';
+  @LocalStorageProp('serverInstanceId') serverInstanceId: string = '';
+  @LocalStorageProp('openEntityDetailEnabled') openEntityDetailEnabled: boolean = false;
   @LocalStorageProp('title') title: string = Localization.t('card_scene_control_title');
   @LocalStorageProp('subtitle') subtitle: string = Localization.t('card_bind_scene');
   @LocalStorageProp('state') state: string = 'unknown';
@@ -61,6 +65,7 @@ struct HarmonySceneServiceCard {
       }
       .layoutWeight(1)
       .alignItems(HorizontalAlign.Start)
+      .onClick(() => this.openEntityDetail())
 
       this.activateButton()
     }
@@ -161,5 +166,21 @@ struct HarmonySceneServiceCard {
 
   private displaySubtitle(): string {
     return this.subtitle.trim();
+  }
+
+  private openEntityDetail(): void {
+    if (!this.bound || !this.openEntityDetailEnabled || this.targetId.trim().length === 0) {
+      return;
+    }
+    postCardAction(this, {
+      action: 'router',
+      abilityName: 'EntryAbility',
+      params: {
+        action: CardEntityDetailLaunchService.ACTION,
+        entityId: this.targetId,
+        serverInstanceId: this.serverInstanceId,
+        formId: this.formId
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Adds a card Want flow for opening Home Assistant entity detail dialogs from service cards.
- Routes light and media card non-button areas to the entity detail dialog, while keeping scene cards opted out.
- Coordinates pending entity-detail requests with dashboard readiness, HA page navigation, server switching, and back handling.
