### PR TITLE
Fix card entity detail want routing

### DIFF
--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -218,7 +218,9 @@ export struct AppRuntimeHost {
   @State assistStartListeningRequested: boolean = false;
   private pendingEntityDetailEntityId: string = '';
   private pendingEntityDetailRequestTick: number = 0;
+  private pendingEntityDetailBaseUrl: string = '';
   private pendingEntityDetailScriptInFlight: boolean = false;
+  private pendingEntityDetailDashboardNavigation: boolean = false;
   private entityDetailOpenedFromCard: boolean = false;
   discoveryAnimationToken: number = 0;
   discoveryAnimationRunning: boolean = false;
@@ -657,20 +659,27 @@ export struct AppRuntimeHost {
   }
 
   private handleExternalBus(payload: Object | string): void {
-    if (ExternalBusService.type(payload) === 'harmony_url_changed') {
+    const type = ExternalBusService.type(payload);
+    if (type === 'harmony_url_changed') {
       const url = ExternalBusService.stringPayload(payload, 'url', '');
       this.rememberDashboardUrl(url);
+      if (this.pendingEntityDetailDashboardNavigation) {
+        if (!this.isPendingEntityDetailDashboardUrl(url)) {
+          return;
+        }
+        this.pendingEntityDetailDashboardNavigation = false;
+      }
       this.runPendingEntityDetailScript();
       return;
     }
-    if (ExternalBusService.type(payload) === 'harmony_card_entity_detail_ready') {
+    if (type === 'harmony_card_entity_detail_ready') {
       const entityId = ExternalBusService.stringPayload(payload, 'entityId', '');
       if (entityId.length === 0 || entityId === this.pendingEntityDetailEntityId.trim()) {
         this.runPendingEntityDetailScript();
       }
       return;
     }
-    if (ExternalBusService.type(payload) === 'harmony_card_entity_detail_closed') {
+    if (type === 'harmony_card_entity_detail_closed') {
       this.entityDetailOpenedFromCard = false;
       return;
     }
@@ -686,15 +695,19 @@ export struct AppRuntimeHost {
   async loadExternalAuthAccessToken(baseUrl: string, forceRefresh: boolean): Promise<string> {
     const context = this.context();
     const activeId = ServerManager.getActiveServerIdSync(context);
-    if (activeId.length === 0) {
+    const normalizedBaseUrl = UrlService.normalizeBaseUrl(baseUrl);
+    let targetId = normalizedBaseUrl.length > 0 ? ServerManager.findServerIdByBaseUrlSync(context, normalizedBaseUrl) : '';
+    if (targetId.length === 0) {
+      targetId = activeId;
+    }
+    if (targetId.length === 0) {
       return this.haAccessToken.trim();
     }
-    const normalizedBaseUrl = UrlService.normalizeBaseUrl(baseUrl);
     const session: ServerAuthSession = forceRefresh
-      ? await ServerAuthRepository.refreshWithBaseUrl(context, activeId, normalizedBaseUrl)
-      : await ServerAuthRepository.loadFreshWithBaseUrl(context, activeId, normalizedBaseUrl);
-    const latestInfo = await ServerManager.getServerInfo(context, activeId);
-    if (StorageService.hasLogin(latestInfo)) {
+      ? await ServerAuthRepository.refreshWithBaseUrl(context, targetId, normalizedBaseUrl)
+      : await ServerAuthRepository.loadFreshWithBaseUrl(context, targetId, normalizedBaseUrl);
+    const latestInfo = await ServerManager.getServerInfo(context, targetId);
+    if (targetId === activeId && StorageService.hasLogin(latestInfo)) {
       AppSessionRuntimeService.applyServerInfoToState(this, latestInfo);
     }
     if (forceRefresh) {
@@ -825,6 +838,10 @@ export struct AppRuntimeHost {
 
   applyDashboardPreferences(): void {
     DashboardRuntimeService.applyDashboardPreferences(this.webCtrl, this);
+    if (this.pendingEntityDetailDashboardNavigation &&
+      this.canOpenEntityDetailInCurrentDashboard(this.pendingEntityDetailBaseUrl)) {
+      this.pendingEntityDetailDashboardNavigation = false;
+    }
     this.runPendingEntityDetailScript();
   }
 
@@ -1015,7 +1032,7 @@ export struct AppRuntimeHost {
     this.ensureCurrentPendingEntityDetailRequest(entityId, requestServerInstanceId, tick);
     const record = await ServerInstanceStore.load(context, serverInstanceId);
     this.ensureCurrentPendingEntityDetailRequest(entityId, requestServerInstanceId, tick);
-    if (!record || !StorageService.hasLogin(record.info)) {
+    if (!record || !StorageService.hasCredentials(record.info)) {
       throw new Error('missing server login');
     }
     const previousRuntime = await ServerInstanceStore.loadRuntime(context);
@@ -1088,41 +1105,23 @@ export struct AppRuntimeHost {
     }
     this.pendingEntityDetailEntityId = entityId;
     this.pendingEntityDetailRequestTick = tick;
+    this.pendingEntityDetailBaseUrl = normalizedBaseUrl;
     this.pendingEntityDetailScriptInFlight = false;
+    this.pendingEntityDetailDashboardNavigation = false;
     this.entityDetailOpenedFromCard = false;
     if (this.canOpenEntityDetailInCurrentDashboard(normalizedBaseUrl)) {
       this.step = AppRoute.DASHBOARD;
       this.runPendingEntityDetailScript();
       return;
     }
-    const dashboardUrl = UrlService.buildDashboardUrl(normalizedBaseUrl);
-    if (this.shouldNavigateCurrentHaPageToDashboardForEntityDetail(normalizedBaseUrl)) {
-      this.openDashboard();
-      this.dashboardUrl = dashboardUrl;
-      this.dashboardCurrentUrl = dashboardUrl;
-      this.tryRunWebScript(CardEntityDetailLaunchService.navigateToDashboardScript(dashboardUrl), (raw): void => {
-        if (!this.isCurrentEntityDetailScriptRequest(entityId, tick)) {
-          return;
-        }
-        const result = String(raw);
-        if (result === 'true' || result === '"true"') {
-          this.runPendingEntityDetailScript();
-          return;
-        }
-        this.dashboardLoadedUrl = '';
-        this.dashboardBridgeReady = false;
-        this.dashboardAuthProvided = false;
-        this.forceLoadDashboard(dashboardUrl);
-      });
-      return;
-    }
+    const dashboardUrl = this.dashboardUrlForEntityDetail(normalizedBaseUrl, entityId);
+    this.pendingEntityDetailDashboardNavigation = true;
     this.openDashboard();
     this.dashboardUrl = dashboardUrl;
     this.dashboardLoadedUrl = '';
     this.dashboardCurrentUrl = dashboardUrl;
     this.dashboardBridgeReady = false;
     this.dashboardAuthProvided = false;
-    this.forceLoadDashboard(dashboardUrl);
   }
 
   private canOpenEntityDetailInCurrentDashboard(baseUrl: string): boolean {
@@ -1133,26 +1132,70 @@ export struct AppRuntimeHost {
     if (!UrlService.isHttpLikeUrl(currentUrl)) {
       return false;
     }
-    if (!this.isLovelaceDashboardPage(currentUrl)) {
-      return false;
-    }
-    return UrlService.endpointKey(currentUrl) === UrlService.endpointKey(baseUrl);
+    return this.isCurrentHaFrontendUrlForEntityDetail(baseUrl, currentUrl);
   }
 
-  private shouldNavigateCurrentHaPageToDashboardForEntityDetail(baseUrl: string): boolean {
-    if (!this.isWebControllerMounted() || this.dashboardInsecureBlocked) {
-      return false;
-    }
+  private dashboardUrlForEntityDetail(baseUrl: string, entityId: string): string {
     const currentUrl = this.currentDashboardUrl();
-    if (!UrlService.isHttpLikeUrl(currentUrl) || this.isLovelaceDashboardPage(currentUrl)) {
-      return false;
+    if (UrlService.isHttpLikeUrl(currentUrl) &&
+      this.isCurrentHaFrontendUrlForEntityDetail(baseUrl, currentUrl)) {
+      return UrlService.buildEntityDetailUrl(UrlService.normalizeBaseUrl(currentUrl), entityId);
     }
-    return UrlService.endpointKey(currentUrl) === UrlService.endpointKey(baseUrl);
+    return UrlService.buildEntityDetailUrl(baseUrl, entityId);
   }
 
-  private isLovelaceDashboardPage(url: string): boolean {
-    const path = UrlService.urlPathOnly(url);
-    return path === '/' || path === '/lovelace' || path.startsWith('/lovelace/');
+  private isCurrentHaFrontendUrlForEntityDetail(baseUrl: string, currentUrl: string): boolean {
+    if (!UrlService.isHttpLikeUrl(currentUrl)) {
+      return false;
+    }
+    const currentKey = UrlService.endpointKey(currentUrl);
+    if (currentKey === UrlService.endpointKey(baseUrl)) {
+      return true;
+    }
+    const aliases = [this.haBaseUrl, this.serverExternalUrl, this.serverInternalUrl];
+    for (let i = 0; i < aliases.length; i++) {
+      const alias = UrlService.normalizeBaseUrl(aliases[i]);
+      if (alias.length > 0 && currentKey === UrlService.endpointKey(alias)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private isPendingEntityDetailDashboardUrl(url: string): boolean {
+    return this.pendingEntityDetailBaseUrl.length > 0 &&
+      this.isCurrentHaFrontendUrlForEntityDetail(this.pendingEntityDetailBaseUrl, url);
+  }
+
+  private navigatePendingEntityDetailToDashboard(entityId: string, tick: number, panelUrl: string = ''): void {
+    const baseUrl = this.pendingEntityDetailBaseUrl;
+    if (baseUrl.length === 0 || !this.isCurrentEntityDetailScriptRequest(entityId, tick)) {
+      return;
+    }
+    const panelPath = panelUrl.trim();
+    const frontendPath = panelPath.length > 0 ? `/${panelPath.startsWith('/') ? panelPath.slice(1) : panelPath}` : '/';
+    const dashboardUrl = UrlService.buildEntityDetailUrl(baseUrl, entityId, frontendPath);
+    this.pendingEntityDetailDashboardNavigation = true;
+    this.openDashboard();
+    this.dashboardUrl = dashboardUrl;
+    this.dashboardCurrentUrl = dashboardUrl;
+    this.tryRunWebScript(CardEntityDetailLaunchService.navigateToDashboardScript(dashboardUrl), (raw): void => {
+      if (!this.isCurrentEntityDetailScriptRequest(entityId, tick)) {
+        return;
+      }
+      const result = String(raw);
+      if (result === 'true' || result === '"true"') {
+        if (this.isPendingEntityDetailDashboardUrl(this.currentDashboardUrl())) {
+          this.pendingEntityDetailDashboardNavigation = false;
+          this.runPendingEntityDetailScript();
+        }
+        return;
+      }
+      this.dashboardLoadedUrl = '';
+      this.dashboardBridgeReady = false;
+      this.dashboardAuthProvided = false;
+      this.forceLoadDashboard(dashboardUrl);
+    });
   }
 
   private runPendingEntityDetailScript(): void {
@@ -1161,7 +1204,7 @@ export struct AppRuntimeHost {
     if (!CardEntityDetailLaunchService.isValidEntityId(entityId)) {
       return;
     }
-    if (this.pendingEntityDetailScriptInFlight) {
+    if (this.pendingEntityDetailDashboardNavigation || this.pendingEntityDetailScriptInFlight) {
       return;
     }
     this.pendingEntityDetailScriptInFlight = true;
@@ -1171,20 +1214,51 @@ export struct AppRuntimeHost {
         this.runPendingEntityDetailScript();
         return;
       }
-      const result = String(raw);
-      if (result === 'opened' || result === '"opened"' || result === 'true' || result === '"true"') {
+      const result = this.normalizeEntityDetailScriptResult(String(raw));
+      if (result === 'opened' || result === 'true') {
         this.pendingEntityDetailEntityId = '';
         this.pendingEntityDetailRequestTick = 0;
+        this.pendingEntityDetailBaseUrl = '';
+        this.pendingEntityDetailDashboardNavigation = false;
         this.entityDetailOpenedFromCard = true;
         return;
       }
-      if (result === 'missing_entity' || result === '"missing_entity"') {
+      if (result === 'missing_entity') {
         this.pendingEntityDetailEntityId = '';
         this.pendingEntityDetailRequestTick = 0;
+        this.pendingEntityDetailBaseUrl = '';
+        this.pendingEntityDetailDashboardNavigation = false;
         this.entityDetailOpenedFromCard = false;
         hilog.warn(DOMAIN, TAG, 'Pending entity detail target is missing. entity=%{public}s', entityId);
+        return;
+      }
+      if (result === 'not_dashboard' || result.startsWith('not_dashboard:')) {
+        this.navigatePendingEntityDetailToDashboard(entityId, requestTick, this.entityDetailDashboardPanelFromResult(result));
       }
     });
+  }
+
+  private normalizeEntityDetailScriptResult(result: string): string {
+    if (result.length >= 2 && result.startsWith('"') && result.endsWith('"')) {
+      return result.slice(1, result.length - 1);
+    }
+    return result;
+  }
+
+  private entityDetailDashboardPanelFromResult(result: string): string {
+    const prefix = 'not_dashboard:';
+    if (!result.startsWith(prefix)) {
+      return '';
+    }
+    const encoded = result.slice(prefix.length).trim();
+    if (encoded.length === 0) {
+      return '';
+    }
+    try {
+      return decodeURIComponent(encoded);
+    } catch (_) {
+      return encoded;
+    }
   }
 
   private shouldCloseCardEntityDetailBeforeDashboardBack(): boolean {

--- a/entry/src/main/ets/features/cards/CardEntityDetailLaunchService.ets
+++ b/entry/src/main/ets/features/cards/CardEntityDetailLaunchService.ets
@@ -54,6 +54,14 @@ export class CardEntityDetailLaunchService {
       `var entityId=${encoded};` +
       `function q(root,selector){return root&&typeof root.querySelector==='function'?root.querySelector(selector):null;}` +
       `function isUpdated(el){return el&&el.hasUpdated!==false;}` +
+      `function dashboardPanelUrl(panels){` +
+      `if(!panels){return '';}` +
+      `if(panels.home&&panels.home.component_name==='home'){return 'home';}` +
+      `if(panels.lovelace&&panels.lovelace.component_name==='lovelace'){return 'lovelace';}` +
+      `for(var key in panels){if(!Object.prototype.hasOwnProperty.call(panels,key)){continue;}var panel=panels[key];` +
+      `if(panel&&(panel.component_name==='home'||panel.component_name==='lovelace')){return key;}}` +
+      `return '';` +
+      `}` +
       `function notifyClosed(){` +
       `if(window.__haHarmonyCardMoreInfoClosedNotified){return;}` +
       `window.__haHarmonyCardMoreInfoClosedNotified=true;` +
@@ -92,33 +100,30 @@ export class CardEntityDetailLaunchService {
       `}catch(e){}` +
       `schedule();` +
       `}` +
-      `function hasRenderedViewContent(layout){` +
-      `var name=String(layout.localName||'');` +
-      `var root=layout.shadowRoot||layout;` +
-      `var cardCount=layout.cards&&layout.cards.length?layout.cards.length:0;` +
-      `var sectionCount=layout.sections&&layout.sections.length?layout.sections.length:0;` +
-      `if((name==='hui-masonry-view'||name==='hui-panel-view'||name==='hui-sidebar-view')&&cardCount>0&&!q(root,'hui-card,hui-card-options')){return false;}` +
-      `if(name==='hui-sections-view'&&sectionCount>0&&!q(root,'hui-section')){return false;}` +
-      `return true;` +
-      `}` +
       `function readiness(ha){` +
       `if(!ha){return 'pending';}` +
       `if(!ha.hass||!ha.hass.states||!ha.shadowRoot||!isUpdated(ha)){return 'pending';}` +
       `if(!ha.hass.states[entityId]){return 'missing_entity';}` +
+      `var panelUrl=ha.hass.panelUrl||'';` +
+      `var slash=location.pathname.indexOf('/',1);` +
+      `var pathPanel=location.pathname==='/'?'':(slash<0?location.pathname.substring(1):location.pathname.substring(1,slash));` +
+      `if(pathPanel&&panelUrl!==pathPanel){return 'pending';}` +
+      `var panelInfo=panelUrl&&ha.hass.panels?ha.hass.panels[panelUrl]:null;` +
+      `if(!panelUrl||!panelInfo){return 'pending';}` +
+      `if(panelInfo.component_name!=='lovelace'&&panelInfo.component_name!=='home'){` +
+      `var targetPanel=dashboardPanelUrl(ha.hass.panels);` +
+      `return targetPanel?'not_dashboard:'+encodeURIComponent(targetPanel):'not_dashboard';` +
+      `}` +
       `var main=q(ha.shadowRoot,'home-assistant-main');` +
       `if(!main||!main.shadowRoot||!isUpdated(main)){return 'pending';}` +
       `var resolver=q(main.shadowRoot,'partial-panel-resolver');` +
       `if(!resolver||!isUpdated(resolver)){return 'pending';}` +
-      `var panel=q(resolver,'ha-panel-lovelace');` +
+      `var panel=q(resolver,panelInfo.component_name==='home'?'ha-panel-home':'ha-panel-lovelace');` +
       `if(!panel||!panel.shadowRoot||!isUpdated(panel)){return 'pending';}` +
       `var root=q(panel.shadowRoot,'hui-root');` +
       `if(!root||!root.shadowRoot||!isUpdated(root)){return 'pending';}` +
       `var viewContainer=q(root.shadowRoot,'hui-view-container#view');` +
       `if(!viewContainer||!isUpdated(viewContainer)){return 'pending';}` +
-      `var view=q(viewContainer,'hui-view');` +
-      `if(!view||!isUpdated(view)){return 'pending';}` +
-      `var layout=view.firstElementChild;` +
-      `if(!layout||!isUpdated(layout)||!hasRenderedViewContent(layout)){return 'pending';}` +
       `return 'ready';` +
       `}` +
       `function clearReadyWatcher(){` +
@@ -147,7 +152,7 @@ export class CardEntityDetailLaunchService {
       `var main=ha&&ha.shadowRoot?q(ha.shadowRoot,'home-assistant-main'):null;` +
       `if(main){observe(main.shadowRoot);}` +
       `var resolver=main&&main.shadowRoot?q(main.shadowRoot,'partial-panel-resolver'):null;` +
-      `var panel=resolver?q(resolver,'ha-panel-lovelace'):null;` +
+      `var panel=resolver?q(resolver,'ha-panel-lovelace,ha-panel-home'):null;` +
       `if(panel){observe(panel.shadowRoot);}` +
       `var root=panel&&panel.shadowRoot?q(panel.shadowRoot,'hui-root'):null;` +
       `if(root){observe(root.shadowRoot);}` +
@@ -156,7 +161,7 @@ export class CardEntityDetailLaunchService {
       `function checkReady(){` +
       `observeReadyRoots();` +
       `var state=readiness(document.querySelector('home-assistant'));` +
-      `if(state==='ready'||state==='missing_entity'){notifyReady();}` +
+      `if(state==='ready'||state==='missing_entity'||state==='not_dashboard'||state.indexOf('not_dashboard:')===0){notifyReady();}` +
       `}` +
       `window.__haHarmonyCardMoreInfoReadyCheck=checkReady;` +
       `function scheduleReady(){Promise.resolve().then(function(){var fn=window.__haHarmonyCardMoreInfoReadyCheck;if(typeof fn==='function'){fn();}});}` +
@@ -172,8 +177,10 @@ export class CardEntityDetailLaunchService {
       `var ha=document.querySelector('home-assistant');` +
       `var state=readiness(ha);` +
       `if(state==='missing_entity'){return 'missing_entity';}` +
+      `if(state==='not_dashboard'||state.indexOf('not_dashboard:')===0){return state;}` +
       `if(state!=='ready'){installReadyWatcher();return 'pending';}` +
       `installCloseWatcher(ha);` +
+      `if(isDialogOpen(ha)){return 'opened';}` +
       `ha.dispatchEvent(new CustomEvent('hass-more-info',{detail:{entityId:entityId},bubbles:true,composed:true}));` +
       `var check=window.__haHarmonyCardMoreInfoCheck;if(typeof check==='function'){Promise.resolve().then(check);}` +
       `return 'opened';` +
@@ -197,10 +204,10 @@ export class CardEntityDetailLaunchService {
       `if(!target){return false;}` +
       `try{` +
       `var url=new URL(target,location.href);` +
-      `if(url.origin!==location.origin){return false;}` +
+      `if(url.origin!==location.origin){url=new URL(url.pathname+url.search+url.hash,location.href);}` +
       `var path=url.pathname+url.search+url.hash;` +
       `if((location.pathname+location.search+location.hash)===path){return true;}` +
-      `history.replaceState(history.state,'',path);` +
+      `try{history.replaceState(history.state,'',path);}catch(e){return false;}` +
       `window.dispatchEvent(new CustomEvent('location-changed',{detail:{replace:true}}));` +
       `return true;` +
       `}catch(e){return false;}` +

--- a/entry/src/main/ets/services/HaConnectionPolicyService.ets
+++ b/entry/src/main/ets/services/HaConnectionPolicyService.ets
@@ -31,7 +31,7 @@ export class HaConnectionPolicyService {
       return HaConnectionPolicyService.blocked('missing_server', false);
     }
     const info = await ServerManager.getServerInfo(context, id);
-    if (!StorageService.hasLogin(info)) {
+    if (!StorageService.hasCredentials(info)) {
       return HaConnectionPolicyService.blocked('missing_login', false);
     }
     const settings = await AppSettingsStore.loadServerConnectionPolicySettings(context, id);

--- a/entry/src/main/ets/services/ServerAuthRepository.ets
+++ b/entry/src/main/ets/services/ServerAuthRepository.ets
@@ -56,6 +56,10 @@ export class ServerAuthRepository {
     const info = await ServerManager.getServerInfo(context, id);
     const session = ServerAuthRepository.session(id, info);
     if (session.accessToken.length === 0) {
+      if (session.refreshToken.length > 0) {
+        const refreshed = await ServerAuthRepository.refreshWithBaseUrl(context, id, refreshBaseUrl);
+        return refreshed.accessToken.length > 0 ? refreshed : session;
+      }
       return session;
     }
     if (!ServerAuthRepository.shouldRefresh(info)) {
@@ -111,7 +115,7 @@ export class ServerAuthRepository {
   }
 
   private static session(serverInstanceId: string, info: StoredServerInfo): ServerAuthSession {
-    if (!StorageService.hasLogin(info)) {
+    if (!StorageService.hasCredentials(info)) {
       return new ServerAuthSessionPayload();
     }
     const session = new ServerAuthSessionPayload();

--- a/entry/src/main/ets/services/ServerInstanceStore.ets
+++ b/entry/src/main/ets/services/ServerInstanceStore.ets
@@ -54,7 +54,7 @@ export class ServerInstanceStore {
         continue;
       }
       const record = await ServerInstanceStore.load(context, id);
-      if (record && StorageService.hasLogin(record.info)) {
+      if (record && StorageService.hasCredentials(record.info)) {
         records.push(record);
       }
     }
@@ -253,7 +253,7 @@ export class ServerInstanceStore {
         ServerInstanceStore.customData(manager, accountName, 'cloudhookUrl'),
         ServerInstanceStore.customData(manager, accountName, 'remoteUiUrl')
       );
-      if (!StorageService.hasLogin(info)) {
+      if (!StorageService.hasCredentials(info)) {
         return undefined;
       }
       return ServerInstanceStore.payload(

--- a/entry/src/main/ets/services/ServerManager.ets
+++ b/entry/src/main/ets/services/ServerManager.ets
@@ -85,15 +85,23 @@ export class ServerManager {
   static async saveActiveServerInfo(context: common.Context, info: StoredServerInfo): Promise<ManagedServer> {
     const normalized = ServerManager.normalizeInfo(info);
     if (!StorageService.hasLogin(normalized)) {
-      const next = await ServerManager.removeActiveServer(context);
-      ServerManager.applyActiveToAppStorage(next);
+      const active = ServerManager.getActiveServerSync(context);
+      if (active &&
+        ServerManager.normalizeBaseUrl(active.info.baseUrl) === ServerManager.normalizeBaseUrl(normalized.baseUrl)) {
+        const next = await ServerManager.removeActiveServer(context);
+        ServerManager.applyActiveToAppStorage(next);
+      } else {
+        ServerManager.applyActiveToAppStorage(normalized);
+      }
       return new ManagedServerPayload();
     }
     const runtime = await ServerInstanceStore.loadRuntime(context);
     const activeId = runtime.activeServerId;
     const active = activeId.length > 0 ? ServerInstanceStore.loadSync(context, activeId) : undefined;
     const existing = await ServerManager.findExistingServerByBaseUrl(context, normalized.baseUrl);
-    const target = active ?? existing;
+    const activeMatches = active &&
+      ServerManager.normalizeBaseUrl(active.info.baseUrl) === ServerManager.normalizeBaseUrl(normalized.baseUrl);
+    const target = activeMatches ? active : existing;
     const saved = await ServerInstanceStore.save(context, target ? target.id : '', target ? target.name : '', normalized);
     runtime.activeServerId = saved.id;
     if (!runtime.serverOrder.includes(saved.id)) {

--- a/entry/src/main/ets/services/StorageService.ets
+++ b/entry/src/main/ets/services/StorageService.ets
@@ -61,6 +61,11 @@ export class StorageService {
     return info.baseUrl.trim().length > 0 && info.accessToken.trim().length > 0;
   }
 
+  static hasCredentials(info: StoredServerInfo): boolean {
+    return info.baseUrl.trim().length > 0 &&
+      (info.accessToken.trim().length > 0 || info.refreshToken.trim().length > 0);
+  }
+
   static storageStatus(info: StoredServerInfo): string {
     if (StorageService.hasLogin(info)) {
       return Localization.t('storage_saved');

--- a/entry/src/main/ets/services/UrlService.ets
+++ b/entry/src/main/ets/services/UrlService.ets
@@ -132,6 +132,59 @@ export class UrlService {
     return UrlService.appendQueryParam(baseUrl, 'external_auth', '1');
   }
 
+  static resolveFrontendUrl(baseUrl: string, path: string): string {
+    const normalizedBase = UrlService.normalizeBaseUrl(baseUrl);
+    if (normalizedBase.length === 0) {
+      return '';
+    }
+    let input = path.trim();
+    let navigateScheme = false;
+    if (input.startsWith('homeassistant://navigate/')) {
+      navigateScheme = true;
+      input = input.slice('homeassistant://navigate/'.length);
+    }
+    if (input.length === 0) {
+      return normalizedBase;
+    }
+    if (navigateScheme && UrlService.isHttpLikeUrl(input)) {
+      const schemeIndex = input.indexOf('://');
+      const hostStart = schemeIndex + 3;
+      let tailStart = input.length;
+      const pathStart = input.indexOf('/', hostStart);
+      const queryStart = input.indexOf('?', hostStart);
+      const hashStart = input.indexOf('#', hostStart);
+      if (pathStart >= 0 && pathStart < tailStart) {
+        tailStart = pathStart;
+      }
+      if (queryStart >= 0 && queryStart < tailStart) {
+        tailStart = queryStart;
+      }
+      if (hashStart >= 0 && hashStart < tailStart) {
+        tailStart = hashStart;
+      }
+      input = tailStart < input.length ? input.slice(tailStart) : '';
+    }
+    if (UrlService.isHttpLikeUrl(input)) {
+      return input;
+    }
+    if (input.startsWith('?') || input.startsWith('#')) {
+      return `${normalizedBase}/${input}`;
+    }
+    return `${normalizedBase}/${input.startsWith('/') ? input.slice(1) : input}`;
+  }
+
+  static buildEntityDetailUrl(baseUrl: string, entityId: string, frontendPath: string = '/'): string {
+    const url = UrlService.resolveFrontendUrl(baseUrl, frontendPath);
+    if (url.length === 0) {
+      return '';
+    }
+    return UrlService.appendQueryParam(
+      UrlService.buildDashboardUrl(url),
+      'more-info-entity-id',
+      entityId
+    );
+  }
+
   static urlPathOnly(url: string): string {
     if (!url) {
       return '';


### PR DESCRIPTION
## Summary
- Route card entity-detail Want launches through the correct Home Assistant frontend panel instead of relying on the root default panel.
- Preserve pending entity-detail launch state across dashboard navigation and retry only after the target frontend is ready.
- Use server-specific credentials and refresh-only sessions for multi-instance card launches.
