### PR TITLE
Fix empty home network summary

### DIFF
--- a/entry/src/main/ets/features/settings/SettingsInteractionRuntimeService.ets
+++ b/entry/src/main/ets/features/settings/SettingsInteractionRuntimeService.ets
@@ -260,20 +260,14 @@ export class SettingsInteractionRuntimeService {
     }
     if (state.homeWifiSsids.indexOf(value) < 0) {
       state.homeWifiSsids.push(value);
-      state.homeNetworkName = SettingsSummaryService.homeNetworkSummary(
-        state.homeWifiSsids,
-        state.homeNetworkName
-      );
+      state.homeNetworkName = '';
     }
     state.homeSsidInput = '';
   }
 
   static removeHomeWifiSsid(value: string, state: SettingsInteractionState): void {
     state.homeWifiSsids = state.homeWifiSsids.filter((item: string): boolean => item !== value);
-    state.homeNetworkName = SettingsSummaryService.homeNetworkSummary(
-      state.homeWifiSsids,
-      state.homeNetworkName
-    );
+    state.homeNetworkName = '';
   }
 
   static saveServerSettingDetail(

--- a/entry/src/main/ets/features/settings/SettingsSectionRuntimeService.ets
+++ b/entry/src/main/ets/features/settings/SettingsSectionRuntimeService.ets
@@ -39,7 +39,6 @@ export interface ServerSettingsSectionInput {
   serverExternalUrl: string;
   haBaseUrl: string;
   homeWifiSsids: string[];
-  homeNetworkName: string;
   serverInternalUrl: string;
   secureConnectionChoice: string;
   trustServer: boolean;
@@ -128,7 +127,6 @@ export class SettingsSectionRuntimeService {
       serverExternalUrl: selectedInfo ? selectedInfo.baseUrl : state.serverExternalUrl,
       haBaseUrl: selectedInfo ? selectedInfo.baseUrl : state.haBaseUrl,
       homeWifiSsids: state.homeWifiSsids,
-      homeNetworkName: state.homeNetworkName,
       serverInternalUrl: state.serverInternalUrl,
       secureConnectionChoice: state.secureConnectionChoice,
       trustServer: state.trustServer,
@@ -167,10 +165,7 @@ export class SettingsSectionRuntimeService {
       serverName: SettingsSummaryService.serverDisplayName(input.serverNameOverride, input.configSummary),
       deviceName: input.deviceName,
       effectiveExternalUrl: SettingsSummaryService.effectiveExternalUrl(input.serverExternalUrl, input.haBaseUrl),
-      homeNetworkSummary: SettingsSummaryService.homeNetworkSummary(
-        input.homeWifiSsids,
-        input.homeNetworkName
-      ),
+      homeNetworkSummary: SettingsSummaryService.homeNetworkSummary(input.homeWifiSsids),
       internalConnectionSummary: SettingsSummaryService.internalConnectionSummary(input.serverInternalUrl),
       securityLevelSummary: SettingsSummaryService.securityLevelSummary(input.secureConnectionChoice),
       trustServer: input.trustServer,

--- a/entry/src/main/ets/features/settings/SettingsSummaryService.ets
+++ b/entry/src/main/ets/features/settings/SettingsSummaryService.ets
@@ -20,20 +20,16 @@ export class SettingsSummaryService {
     return SettingsSummaryService.normalizeBaseUrl(baseUrl);
   }
 
-  static homeNetworkSummary(
-    homeWifiSsids: string[],
-    homeNetworkName: string
-  ): string {
-    const parts: string[] = [];
-    let i = 0;
-    while (i < homeWifiSsids.length) {
-      parts.push(homeWifiSsids[i]);
-      i += 1;
+  static homeNetworkSummary(homeWifiSsids: string[]): string {
+    let i = homeWifiSsids.length - 1;
+    while (i >= 0) {
+      const value = homeWifiSsids[i].trim();
+      if (value.length > 0) {
+        return value;
+      }
+      i -= 1;
     }
-    if (parts.length > 0) {
-      return parts.join(', ');
-    }
-    return homeNetworkName.trim().length > 0 ? homeNetworkName.trim() : Localization.t('common_not_set');
+    return Localization.t('common_not_set');
   }
 
   static internalConnectionSummary(serverInternalUrl: string): string {

--- a/entry/src/main/ets/services/AppSettingsStore.ets
+++ b/entry/src/main/ets/services/AppSettingsStore.ets
@@ -18,6 +18,7 @@ export interface ServerConnectionPolicySettings {
 }
 
 export class AppSettingsStore {
+  private static readonly MISSING_HOME_WIFI_SSIDS_JSON = '__missing_home_wifi_ssids_json__';
 
   static async loadWebsocketMode(context: common.Context): Promise<string> {
     const pref = await AppSettingsStore.getPreferences(context);
@@ -116,6 +117,7 @@ export class AppSettingsStore {
       prioritizeInternal
     );
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.HOME_WIFI_SSIDS_JSON, JSON.stringify(settings.wifiSsids));
+    await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.HOME_NETWORK_NAME, '');
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.PRIORITIZE_INTERNAL, settings.prioritizeInternal);
     await AppSettingsStore.flush(pref);
   }
@@ -150,18 +152,25 @@ export class AppSettingsStore {
     pref: preferences.Preferences,
     serverId: string
   ): Promise<HomeNetworkSettings> {
-    const rawWifiSsids = AppSettingsValueCodec.stringArrayField(
-      await AppSettingsStore.getValue(pref, serverId, AppSettingsKeys.HOME_WIFI_SSIDS_JSON, '[]')
+    const rawWifiSsidsValue = await AppSettingsStore.getValue(
+      pref,
+      serverId,
+      AppSettingsKeys.HOME_WIFI_SSIDS_JSON,
+      AppSettingsStore.MISSING_HOME_WIFI_SSIDS_JSON
     );
+    const rawWifiSsids = AppSettingsValueCodec.stringArrayField(
+      rawWifiSsidsValue
+    );
+    const shouldUseLegacyHomeNetworkName = rawWifiSsidsValue === AppSettingsStore.MISSING_HOME_WIFI_SSIDS_JSON;
     const legacyHomeNetworkName = AppSettingsValueCodec.stringField(
       await AppSettingsStore.getValue(pref, serverId, AppSettingsKeys.HOME_NETWORK_NAME, '')
     );
     const settings = HomeNetworkService.settingsFromStored(
       rawWifiSsids,
-      legacyHomeNetworkName,
+      shouldUseLegacyHomeNetworkName ? legacyHomeNetworkName : '',
       AppSettingsValueCodec.booleanField(await AppSettingsStore.getValue(pref, serverId, AppSettingsKeys.PRIORITIZE_INTERNAL, false))
     );
-    if (rawWifiSsids.length === 0 && settings.wifiSsids.length > 0) {
+    if (shouldUseLegacyHomeNetworkName && rawWifiSsids.length === 0 && settings.wifiSsids.length > 0) {
       await AppSettingsStore.putValue(pref, AppSettingsStore.valueKey(serverId, AppSettingsKeys.HOME_WIFI_SSIDS_JSON), JSON.stringify(settings.wifiSsids));
       await AppSettingsStore.flush(pref);
     }
@@ -174,7 +183,7 @@ export class AppSettingsStore {
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.SERVER_EXTERNAL_URL, AppStorage.get<string>('serverExternalUrl') ?? '');
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.SERVER_INTERNAL_URL, AppStorage.get<string>('serverInternalUrl') ?? '');
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.SECURE_CONNECTION_CHOICE, AppStorage.get<string>('secureConnectionChoice') ?? '');
-    await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.HOME_NETWORK_NAME, AppStorage.get<string>('homeNetworkName') ?? '');
+    await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.HOME_NETWORK_NAME, '');
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.TRUST_SERVER, AppStorage.get<boolean>('trustServer') ?? false);
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.APP_LOCK_ENABLED, AppStorage.get<boolean>('appLockEnabled') ?? false);
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.APP_LOCK_HOME_BYPASS, AppStorage.get<boolean>('appLockHomeBypass') ?? false);


### PR DESCRIPTION
## Summary
- Show the latest non-empty home Wi-Fi SSID in the home network summary.
- Reuse the existing `common_not_set` text when no Wi-Fi SSIDs are stored.
- Stop falling back to stale legacy `HOME_NETWORK_NAME` after the Wi-Fi SSID list has been explicitly saved as empty.

## Root cause
The summary still considered the legacy home network name after the user removed all stored Wi-Fi SSIDs, so the last-added value could remain visible.
