### PR TITLE
Default theme to follow system

### DIFF
--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -128,7 +128,7 @@ export struct AppRuntimeHost {
   @StorageLink('autoPlayVideoEnabled') @Watch('onAppSettingChanged') autoPlayVideoEnabled: boolean = false;
   @StorageLink('alwaysShowFirstViewOnAppStartEnabled') @Watch('onAppSettingChanged') alwaysShowFirstViewOnAppStartEnabled: boolean = false;
   @StorageLink('appLanguage') @Watch('onAppSettingChanged') appLanguage: string = 'default';
-  @StorageLink('appTheme') @Watch('onAppSettingChanged') appTheme: string = 'light';
+  @StorageLink('appTheme') @Watch('onAppSettingChanged') appTheme: string = 'system';
   @StorageLink('serviceCardUpdateFrequency') @Watch('onAppSettingChanged') serviceCardUpdateFrequency: string = 'default';
   @StorageLink('notificationUnreadCount') @Watch('onNotificationUnreadCountChanged') notificationUnreadCount: number = 0;
   @StorageLink('appResolvedDark') appResolvedDark: boolean = false;

--- a/entry/src/main/ets/app/AppRuntimeShellHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeShellHost.ets
@@ -78,7 +78,7 @@ const EMPTY_SETTINGS_SNAPSHOT: SettingsRuntimeSnapshot = {
   screenOrientation: 'system',
   pageZoomLevel: '100',
   appLanguage: 'default',
-  appTheme: 'light',
+  appTheme: 'system',
   secureConnectionChoice: '',
   websocketMode: 'system',
   serviceCardUpdateFrequency: 'default',
@@ -173,7 +173,7 @@ const EMPTY_WEB_SNAPSHOT: AppWebRuntimeSnapshot = {
   pageZoomLevel: '100',
   pinchToZoomEnabled: false,
   autoPlayVideoEnabled: false,
-  appTheme: 'light',
+  appTheme: 'system',
   dark: false
 };
 

--- a/entry/src/main/ets/app/AppStorageDefaults.ets
+++ b/entry/src/main/ets/app/AppStorageDefaults.ets
@@ -51,7 +51,7 @@ export class AppStorageDefaults {
     AppStorage.setOrCreate<boolean>('autoPlayVideoEnabled', AppStorage.get<boolean>('autoPlayVideoEnabled') ?? false);
     AppStorage.setOrCreate<boolean>('alwaysShowFirstViewOnAppStartEnabled', AppStorage.get<boolean>('alwaysShowFirstViewOnAppStartEnabled') ?? false);
     AppStorage.setOrCreate<string>('appLanguage', AppStorage.get<string>('appLanguage') ?? 'default');
-    AppStorage.setOrCreate<string>('appTheme', AppStorage.get<string>('appTheme') ?? 'light');
+    AppStorage.setOrCreate<string>('appTheme', AppStorage.get<string>('appTheme') ?? 'system');
     AppStorage.setOrCreate<string>('serviceCardUpdateFrequency', AppStorage.get<string>('serviceCardUpdateFrequency') ?? 'default');
     AppStorage.setOrCreate<boolean>('appResolvedDark', AppStorage.get<boolean>('appResolvedDark') ?? false);
     AppStorage.setOrCreate<number>('appConfigTick', AppStorage.get<number>('appConfigTick') ?? 0);

--- a/entry/src/main/ets/app/AppWebRuntimeCoordinatorHost.ets
+++ b/entry/src/main/ets/app/AppWebRuntimeCoordinatorHost.ets
@@ -19,7 +19,7 @@ const DEFAULT_WEB_RUNTIME_SNAPSHOT: AppWebRuntimeSnapshot = {
   pageZoomLevel: '100',
   pinchToZoomEnabled: false,
   autoPlayVideoEnabled: false,
-  appTheme: 'light',
+  appTheme: 'system',
   dark: false
 };
 

--- a/entry/src/main/ets/app/AppWebRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppWebRuntimeHost.ets
@@ -24,7 +24,7 @@ export struct AppWebRuntimeHost {
   @Prop pageZoomLevel: string = '100';
   @Prop pinchToZoomEnabled: boolean = false;
   @Prop autoPlayVideoEnabled: boolean = false;
-  @Prop appTheme: string = 'light';
+  @Prop appTheme: string = 'system';
   @Prop dark: boolean = false;
 
   controller: web_webview.WebviewController = new web_webview.WebviewController();

--- a/entry/src/main/ets/features/dashboard/DashboardPage.ets
+++ b/entry/src/main/ets/features/dashboard/DashboardPage.ets
@@ -25,7 +25,7 @@ export struct DashboardPage {
   @Prop
   autoPlayVideoEnabled: boolean = false;
   @Prop
-  appTheme: string = 'light';
+  appTheme: string = 'system';
   @Prop
   isDarkTheme: boolean = false;
   controller: web_webview.WebviewController = new web_webview.WebviewController();

--- a/entry/src/main/ets/features/onboarding/OnboardingAppRuntimeHost.ets
+++ b/entry/src/main/ets/features/onboarding/OnboardingAppRuntimeHost.ets
@@ -66,7 +66,7 @@ const DEFAULT_WEB_RUNTIME_SNAPSHOT: AppWebRuntimeSnapshot = {
   pageZoomLevel: '100',
   pinchToZoomEnabled: false,
   autoPlayVideoEnabled: false,
-  appTheme: 'light',
+  appTheme: 'system',
   dark: false
 };
 

--- a/entry/src/main/ets/features/settings/SettingsDetailHost.ets
+++ b/entry/src/main/ets/features/settings/SettingsDetailHost.ets
@@ -26,7 +26,7 @@ export struct SettingsDetailHost {
   @Prop screenOrientation: string = 'system';
   @Prop pageZoomLevel: string = '100';
   @Prop appLanguage: string = 'default';
-  @Prop appTheme: string = 'light';
+  @Prop appTheme: string = 'system';
   @Prop serviceCardUpdateFrequency: string = 'default';
   onBackToServer: () => void = () => {};
   onBackToCompanion: () => void = () => {};

--- a/entry/src/main/ets/features/settings/SettingsNavigationRoutes.ets
+++ b/entry/src/main/ets/features/settings/SettingsNavigationRoutes.ets
@@ -55,7 +55,7 @@ const DEFAULT_SETTINGS_RUNTIME_SNAPSHOT: SettingsRuntimeSnapshot = {
   screenOrientation: 'system',
   pageZoomLevel: '100',
   appLanguage: 'default',
-  appTheme: 'light',
+  appTheme: 'system',
   secureConnectionChoice: '',
   websocketMode: 'system',
   serviceCardUpdateFrequency: 'default',

--- a/entry/src/main/ets/features/settings/SettingsRuntimeCoordinatorHost.ets
+++ b/entry/src/main/ets/features/settings/SettingsRuntimeCoordinatorHost.ets
@@ -45,7 +45,7 @@ const DEFAULT_SETTINGS_RUNTIME_SNAPSHOT: SettingsRuntimeSnapshot = {
   screenOrientation: 'system',
   pageZoomLevel: '100',
   appLanguage: 'default',
-  appTheme: 'light',
+  appTheme: 'system',
   secureConnectionChoice: '',
   websocketMode: 'system',
   serviceCardUpdateFrequency: 'default',

--- a/entry/src/main/ets/features/settings/SettingsSurfaceRuntimeHost.ets
+++ b/entry/src/main/ets/features/settings/SettingsSurfaceRuntimeHost.ets
@@ -20,7 +20,7 @@ export struct CompanionSettingsSurfaceHost {
   @Prop screenOrientation: string = 'system';
   @Prop pageZoomLevel: string = '100';
   @Prop appLanguage: string = 'default';
-  @Prop appTheme: string = 'light';
+  @Prop appTheme: string = 'system';
   @Prop secureConnectionChoice: string = '';
   @Prop websocketMode: string = 'system';
   @Prop serviceCardUpdateFrequency: string = 'default';
@@ -136,7 +136,7 @@ export struct ServerSettingsSurfaceHost {
       screenOrientation: 'system',
       pageZoomLevel: '100',
       appLanguage: 'default',
-      appTheme: 'light',
+      appTheme: 'system',
       secureConnectionChoice: this.secureConnectionChoice,
       websocketMode: 'system',
       serviceCardUpdateFrequency: 'default',
@@ -180,7 +180,7 @@ export struct SettingsDetailSurfaceHost {
   @Prop screenOrientation: string = 'system';
   @Prop pageZoomLevel: string = '100';
   @Prop appLanguage: string = 'default';
-  @Prop appTheme: string = 'light';
+  @Prop appTheme: string = 'system';
   @Prop serviceCardUpdateFrequency: string = 'default';
 
   gestureActionValue: (key: string) => string = () => '';

--- a/entry/src/main/ets/services/AppSettingsStore.ets
+++ b/entry/src/main/ets/services/AppSettingsStore.ets
@@ -225,7 +225,7 @@ export class AppSettingsStore {
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.AUTO_PLAY_VIDEO_ENABLED, AppStorage.get<boolean>('autoPlayVideoEnabled') ?? false);
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.ALWAYS_SHOW_FIRST_VIEW, AppStorage.get<boolean>('alwaysShowFirstViewOnAppStartEnabled') ?? false);
     await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.APP_LANGUAGE, AppStorage.get<string>('appLanguage') ?? 'default');
-    await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.APP_THEME, AppStorage.get<string>('appTheme') ?? 'light');
+    await AppSettingsStore.putActiveValue(context, pref, AppSettingsKeys.APP_THEME, AppStorage.get<string>('appTheme') ?? 'system');
     const serviceCardUpdateFrequency = AppSettingsStore.normalizeServiceCardUpdateFrequency(
       AppStorage.get<string>('serviceCardUpdateFrequency') ?? 'default',
       websocketMode
@@ -384,7 +384,7 @@ export class AppSettingsStore {
     );
     AppSettingsStore.setAppStorage<string>(
       'appTheme',
-      AppSettingsValueCodec.stringField(await AppSettingsStore.getValue(pref, serverId, AppSettingsKeys.APP_THEME, 'light'))
+      AppSettingsValueCodec.stringField(await AppSettingsStore.getValue(pref, serverId, AppSettingsKeys.APP_THEME, 'system'))
     );
     const storedServiceCardUpdateFrequency = await AppSettingsStore.getValue(pref, serverId, AppSettingsKeys.SERVICE_CARD_UPDATE_FREQUENCY, 'default');
     const serviceCardUpdateFrequency = AppSettingsStore.normalizeServiceCardUpdateFrequency(storedServiceCardUpdateFrequency, websocketMode);


### PR DESCRIPTION
## Summary
- Change the default app theme from light to follow system.
- Update runtime, AppStorage, persisted-settings fallback, and empty snapshot defaults to use `system`.
- Preserve existing explicit light and dark options.

