### PR TITLE
Fix settings title bar buttons

### DIFF
--- a/entry/src/main/ets/features/settings/components/SettingsUiConfig.ets
+++ b/entry/src/main/ets/features/settings/components/SettingsUiConfig.ets
@@ -4,6 +4,7 @@ import {
   HdsNavigationMenuItemOptions,
   HdsNavigationTitle,
   HdsNavigationTitleBarOptions,
+  hdsMaterial,
   IconStyleMode,
   ScrollEffectOptions,
   ScrollEffectType,
@@ -109,7 +110,7 @@ export class SettingsUiConfig {
       icon: $r('sys.symbol.questionmark_circle'),
       label: '?',
       action: onHelp ?? ((): void => {}),
-      isEnabled: onHelp !== undefined
+      isEnabled: true
     };
   }
 
@@ -125,7 +126,11 @@ export class SettingsUiConfig {
       scrollEffectType: ScrollEffectType.GRADIENT_BLUR
     };
     return {
-      scrollEffectOpts: scrollEffectOpts
+      scrollEffectOpts: scrollEffectOpts,
+      systemMaterialEffect: {
+        materialType: hdsMaterial.MaterialType.IMMERSIVE,
+        materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
+      }
     };
   }
 


### PR DESCRIPTION
## Summary
- Keep the settings title bar help button enabled when no explicit handler is provided.
- Match the official HDS title bar material configuration so title bar buttons keep the intended visual behavior while scrolling.

## Notes
- This uses HDS material APIs introduced in API 23. The companion SDK profile update is split into a separate PR.
