### PR TITLE
Fix build SDK profile version

### DIFF
--- a/build-profile.json5
+++ b/build-profile.json5
@@ -4,8 +4,8 @@
     "products": [
       {
         "name": "default",
-        "targetSdkVersion": "6.0.2(22)",
-        "compatibleSdkVersion": "6.0.1(21)",
+        "targetSdkVersion": "6.1.0(23)",
+        "compatibleSdkVersion": "6.1.0(23)",
         "runtimeOS": "HarmonyOS",
         "buildOption": {
           "strictMode": {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -15,6 +15,9 @@ $localDir = Join-Path $repoRoot '.local'
 $activeProfile = Join-Path $repoRoot 'build-profile.json5'
 $hvigorw = 'D:\DevEco Studio\tools\hvigor\bin\hvigorw.bat'
 $devecoSdk = 'D:\DevEco Studio\sdk'
+$targetSdkVersion = '6.1.0(23)'
+$compatibleSdkVersion = '6.1.0(23)'
+$profileSdkChanged = $false
 
 function ProfilePath([string]$name) {
   return Join-Path $localDir "build-profile.$name.json5"
@@ -26,9 +29,23 @@ function EnsureLocalDir {
   }
 }
 
+function Set-ProfileSdkVersions([string]$path) {
+  $content = Get-Content -LiteralPath $path -Raw
+  $updated = $content -replace '("targetSdkVersion"\s*:\s*)"[^"]+"', "`$1`"$targetSdkVersion`""
+  $updated = $updated -replace '("compatibleSdkVersion"\s*:\s*)"[^"]+"', "`$1`"$compatibleSdkVersion`""
+  if ($updated -eq $content) {
+    return $false
+  }
+  $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+  [System.IO.File]::WriteAllText($path, $updated, $utf8NoBom)
+  return $true
+}
+
 function Save-Profile([string]$name) {
   EnsureLocalDir
-  Copy-Item -LiteralPath $activeProfile -Destination (ProfilePath $name) -Force
+  $destination = ProfilePath $name
+  Copy-Item -LiteralPath $activeProfile -Destination $destination -Force
+  [void](Set-ProfileSdkVersions $destination)
   Write-Host "Saved current build-profile.json5 as .local/build-profile.$name.json5"
 }
 
@@ -37,7 +54,10 @@ function Use-Profile([string]$name) {
   if (-not (Test-Path -LiteralPath $source)) {
     throw "Missing $source. Switch DevEco to $name once, then run: .\scripts\build.ps1 save $name"
   }
+  $sourceSdkChanged = Set-ProfileSdkVersions $source
   Copy-Item -LiteralPath $source -Destination $activeProfile -Force
+  $activeSdkChanged = Set-ProfileSdkVersions $activeProfile
+  $script:profileSdkChanged = $sourceSdkChanged -or $activeSdkChanged
   Write-Host "Using .local/build-profile.$name.json5"
 }
 
@@ -46,8 +66,13 @@ function Invoke-Hvigor([string]$buildTarget) {
     throw "Hvigor wrapper not found: $hvigorw"
   }
   $env:DEVECO_SDK_HOME = $devecoSdk
+  $tasks = @()
+  if ($script:profileSdkChanged) {
+    $tasks += 'clean'
+  }
   if ($buildTarget -eq 'app') {
-    & $hvigorw --no-daemon assembleApp
+    $tasks += 'assembleApp'
+    & $hvigorw --no-daemon @tasks
     if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE
     }
@@ -56,7 +81,8 @@ function Invoke-Hvigor([string]$buildTarget) {
       Select-Object -First 1 -ExpandProperty FullName
     return
   }
-  & $hvigorw --no-daemon --mode module -p module=entry assembleHap
+  $tasks += 'assembleHap'
+  & $hvigorw --no-daemon --mode module -p module=entry @tasks
   if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
   }


### PR DESCRIPTION
## Summary
- Update the public build profile target and compatible SDK versions to `6.1.0(23)`.
- Normalize local debug/release profiles to API 23 when saving or switching build profiles.
- Trigger a one-time `clean` when the profile SDK is corrected so ArkTS diagnostics do not keep stale API 21 warnings.

## Validation
- Verified the remote branch diff against `main` contains only `build-profile.json5` and `scripts/build.ps1`.
- Verified locally that `scripts/build.ps1` parses successfully.
- Earlier local `./scripts/build.ps1 debug hap` completed successfully and no longer emitted the `SettingsUiConfig/hdsMaterial` API 21 warning after SDK 23 was applied.