### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Report a reproducible bug in HA Companion for HarmonyOS
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+<!--
+Before submitting:
+- Make sure you are using the latest version of HA Companion for HarmonyOS.
+- Make sure your Home Assistant instance is on a supported version.
+- Search existing issues to confirm this has not already been reported.
+- If the issue only happens inside the Home Assistant dashboard or Lovelace UI, it may need to be reported to Home Assistant frontend as well.
+
+Do not delete any fields from this template. Complete reports are easier to reproduce and fix.
+-->
+
+**App version:**
+
+**HarmonyOS version:**
+
+**Device model:**
+
+**Home Assistant version:**
+
+**Last working app or Home Assistant version, if known:**
+
+**Description of the problem:**
+
+**Steps to reproduce:**
+1.
+2.
+3.
+
+**Expected behavior:**
+
+**Actual behavior:**
+
+**App logs:**
+
+<!-- Paste relevant log snippets if available. Do not include tokens, secret URLs, or other sensitive information. -->
+```text
+
+```
+
+**Screenshots or screen recordings:**
+
+**Additional information:**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Dashboard or Home Assistant frontend issue
+    url: https://github.com/home-assistant/frontend/issues/new/choose
+    about: If the problem only appears inside the Home Assistant dashboard or Lovelace UI, report it to Home Assistant frontend.
+  - name: Home Assistant help and support
+    url: https://www.home-assistant.io/help
+    about: GitHub issues are for reproducible bugs. For setup questions and support, use the Home Assistant help channels.
+  - name: Home Assistant Companion documentation
+    url: https://companion.home-assistant.io/
+    about: Check the companion app documentation for troubleshooting and configuration guidance.


### PR DESCRIPTION
## Summary

Add GitHub issue templates for HA Companion for HarmonyOS.

- Add an English bug report template tailored for HarmonyOS app reports.
- Add issue template configuration that disables blank issues and links users to relevant Home Assistant support/frontend/documentation resources.

## Related Issue

N/A

## Verification

- HarmonyOS version: N/A
- Device model: N/A
- API version: N/A

Checked locally:

- `git diff --check -- .github/ISSUE_TEMPLATE/bug_report.md .github/ISSUE_TEMPLATE/config.yml`
- Verified the issue template files are ASCII-only.

## Screenshots or Recordings

N/A

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [x] User-facing behavior has been verified on a HarmonyOS device or emulator. N/A, repository issue template only.
- [x] UI changes have screenshots or recordings when applicable. N/A.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes

This follows the structure of the Home Assistant Android issue templates while keeping only the templates needed for this repository.