### PR TITLE
Add Material Symbols license entry

### DIFF
--- a/entry/src/main/ets/features/settings/OpenSourceLicensesPage.ets
+++ b/entry/src/main/ets/features/settings/OpenSourceLicensesPage.ets
@@ -32,6 +32,12 @@ export struct OpenSourceLicensesPage {
         description: Localization.t('license_ha_icon_assets')
       },
       {
+        name: 'Google Material Symbols Rounded',
+        version: 'subset',
+        license: 'Apache-2.0',
+        description: Localization.t('license_google_material_symbols')
+      },
+      {
         name: 'HarmonyOS SDK',
         version: '6.x',
         license: 'SDK',

--- a/entry/src/main/ets/shared/i18n/resources/LocalizationEnUs.ets
+++ b/entry/src/main/ets/shared/i18n/resources/LocalizationEnUs.ets
@@ -193,6 +193,7 @@ export const EN_US: Map<string, string> = new Map<string, string>([
   ['settings_open_source_licenses', 'Open source licenses'],
   ['settings_open_source_licenses_summary', 'View third-party open source licenses.'],
   ['license_ha_icon_assets', 'Icon assets in the app come from Home Assistant project resources and were converted for HarmonyOS.'],
+  ['license_google_material_symbols', 'The app uses a subset of Google Material Symbols Rounded generated from Google Material Symbols font files.'],
   ['license_harmony_sdk', 'The app is built with HarmonyOS SDK and system capabilities. Related terms follow the agreements bundled with the Huawei developer toolchain.'],
   ['settings_privacy_policy', 'Privacy policy'],
   ['settings_privacy_policy_summary', 'View the Home Assistant privacy policy and Huawei privacy statement'],

--- a/entry/src/main/ets/shared/i18n/resources/LocalizationZhCn.ets
+++ b/entry/src/main/ets/shared/i18n/resources/LocalizationZhCn.ets
@@ -193,6 +193,7 @@ export const ZH_CN: Map<string, string> = new Map<string, string>([
   ['settings_open_source_licenses', '开源许可'],
   ['settings_open_source_licenses_summary', '查看第三方开源许可。'],
   ['license_ha_icon_assets', '应用内图标资源来自 Home Assistant 项目资源，并已转换为 HarmonyOS 可用资源。'],
+  ['license_google_material_symbols', '应用使用从 Google Material Symbols 字体文件生成的 Google Material Symbols Rounded 子集。'],
   ['license_harmony_sdk', '应用使用 HarmonyOS SDK 和系统能力构建，相关许可和条款以华为开发者工具链随附协议为准。'],
   ['settings_privacy_policy', '隐私政策'],
   ['settings_privacy_policy_summary', '查看 Home Assistant 隐私政策和华为隐私声明'],


### PR DESCRIPTION
## Summary
- Add Google Material Symbols Rounded to the open source licenses page.
- Add English and Simplified Chinese descriptions for the Material Symbols license entry.

## Related Issue
N/A

## Verification

- HarmonyOS version: Not device verified
- Device model: Not device verified
- API version: Not device verified

Additional check:
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\build.ps1 debug hap`

## Screenshots or Recordings
N/A

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [ ] User-facing behavior has been verified on a HarmonyOS device or emulator.
- [ ] UI changes have screenshots or recordings when applicable.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes
- Build completed successfully with existing ArkTS warnings unrelated to this change.