### PR TITLE
Fix location runtime geofence reporting

### DIFF
--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -113,7 +113,7 @@ export struct AppRuntimeHost {
   @StorageLink('sensorPluggedTypeEnabled') @Watch('onSensorPreferenceChanged') sensorPluggedTypeEnabled: boolean = false;
   @StorageLink('sensorBearerTypesEnabled') @Watch('onSensorPreferenceChanged') sensorBearerTypesEnabled: boolean = false;
   @StorageLink('sensorLastUpdateTriggerEnabled') @Watch('onSensorPreferenceChanged') sensorLastUpdateTriggerEnabled: boolean = false;
-  @StorageLink('sensorLocationEnabled') @Watch('onSensorPreferenceChanged') sensorLocationEnabled: boolean = false;
+  @StorageLink('sensorLocationEnabled') @Watch('onSensorPreferenceChanged') sensorLocationBackgroundEnabled: boolean = false;
   @StorageLink('sensorZoneBackgroundEnabled') @Watch('onSensorPreferenceChanged') sensorZoneBackgroundEnabled: boolean = false;
   @StorageLink('sensorAccurateLocationEnabled') @Watch('onSensorPreferenceChanged') sensorAccurateLocationEnabled: boolean = false;
   @StorageLink('sensorDirectEnabledJson') @Watch('onSensorDirectEnabledChanged') sensorDirectEnabledJson: string = '[]';

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -9,7 +9,6 @@ import { HaLocationRuntimeService } from '../features/location/HaLocationRuntime
 import { AppStorageDefaults } from '../app/AppStorageDefaults';
 import { AppSettingsStore } from '../services/AppSettingsStore';
 import { DiscoveryCacheService } from '../services/DiscoveryCacheService';
-import { HARMONY_GEOFENCE_ACTION } from '../services/HarmonyLocationService';
 import { ServerManager } from '../services/ServerManager';
 import { CardEntityDetailLaunchService } from '../features/cards/CardEntityDetailLaunchService';
 
@@ -21,7 +20,6 @@ export default class EntryAbility extends UIAbility {
 
   onCreate(want: Want, launchParam: AbilityConstant.LaunchParam): void {
     AppStorageDefaults.register();
-    this.handleLocationWant(want);
     this.handleEntityDetailWant(want);
     LongRunningTaskService.setRecoveryHandler((context): void => {
       if ((AppStorage.get<string>('websocketMode') ?? 'system') !== 'always') {
@@ -39,7 +37,6 @@ export default class EntryAbility extends UIAbility {
   }
 
   onNewWant(want: Want, _launchParam: AbilityConstant.LaunchParam): void {
-    this.handleLocationWant(want);
     this.handleEntityDetailWant(want);
   }
 
@@ -149,20 +146,6 @@ export default class EntryAbility extends UIAbility {
     const baseUrl = AppStorage.get<string>('haBaseUrl') ?? '';
     const token = AppStorage.get<string>('haAccessToken') ?? '';
     return baseUrl.trim().length > 0 && token.trim().length > 0;
-  }
-
-  private handleLocationWant(want: Want): void {
-    if (want.action !== HARMONY_GEOFENCE_ACTION) {
-      return;
-    }
-    ServerManager.restoreActiveToAppStorage(this.context)
-      .then((): Promise<void> => AppSettingsStore.restoreToAppStorage(this.context))
-      .then((): void => {
-        HaLocationRuntimeService.handleGeofenceWant(this.context);
-      })
-      .catch((err: Error): void => {
-        hilog.warn(DOMAIN, TAG, 'Failed to handle geofence want. Cause: %{public}s', err.message);
-      });
   }
 
   private handleEntityDetailWant(want: Want): void {

--- a/entry/src/main/ets/features/location/HaLocationRuntimeService.ets
+++ b/entry/src/main/ets/features/location/HaLocationRuntimeService.ets
@@ -2,8 +2,6 @@ import common from '@ohos.app.ability.common';
 import { HaConnectionPolicyService } from '../../services/HaConnectionPolicyService';
 import { HarmonySensorService, SensorPreferenceSnapshot } from '../../services/HarmonySensorService';
 import {
-  HarmonyGeofenceStatus,
-  HarmonyGeofenceTransition,
   HarmonyLocationService,
   HarmonyLocationSnapshot,
   HarmonyLocationZone
@@ -35,48 +33,32 @@ export class HaLocationRuntimeService {
   private static currentZoneName = '';
   private static running = false;
   private static zonesRefreshing = false;
-  private static geofenceRefreshing = false;
   private static syncing = false;
   private static pendingSyncReason = '';
 
   static ensureRunning(context: common.Context, reason: string = 'location_runtime_ensure'): void {
     HaLocationRuntimeService.context = context;
     const snapshot = HaLocationRuntimeService.snapshot();
-    if (!snapshot.registered || snapshot.locationSentMode === 'never' ||
-      !SensorRuntimePresenter.hasAnyLocationSensorEnabled(snapshot.flags)) {
+    if (!snapshot.registered || !HaLocationRuntimeService.shouldUseBackgroundRuntime(snapshot)) {
       HaLocationRuntimeService.stop();
       HaLocationRuntimeService.syncSensors(reason);
       return;
     }
 
-    const useContinuousLocation = HaLocationRuntimeService.shouldUseContinuousLocation(snapshot);
-    if (snapshot.flags.locationBackgroundEnabled && useContinuousLocation) {
-      LongRunningTaskService.ensureLocationActive(context as common.UIAbilityContext).catch((): void => {});
-    } else {
-      LongRunningTaskService.stopLocation(context as common.UIAbilityContext).catch((): void => {});
-    }
+    LongRunningTaskService.ensureLocationActive(context as common.UIAbilityContext).catch((): void => {});
     HaLocationRuntimeService.locationEnabled = HaLocationRuntimeService.locationService.getLocationEnabled();
     HaLocationRuntimeService.startEnabledWatch();
-    if (useContinuousLocation) {
-      HaLocationRuntimeService.startLocationWatch();
-    } else {
-      HaLocationRuntimeService.running = false;
-      HaLocationRuntimeService.locationService.stopLocationWatch();
-    }
-    HaLocationRuntimeService.refreshZones(false);
+    HaLocationRuntimeService.startLocationWatch();
     HaLocationRuntimeService.refreshCurrentLocation(reason);
   }
 
   static refreshOnce(context: common.Context, reason: string = 'location_background_work'): void {
     HaLocationRuntimeService.context = context;
     const snapshot = HaLocationRuntimeService.snapshot();
-    if (!snapshot.registered || !snapshot.flags.locationBackgroundEnabled ||
-      snapshot.locationSentMode === 'never' ||
-      !SensorRuntimePresenter.hasAnyLocationSensorEnabled(snapshot.flags)) {
+    if (!snapshot.registered || !HaLocationRuntimeService.shouldUseBackgroundRuntime(snapshot)) {
       return;
     }
     HaLocationRuntimeService.locationEnabled = HaLocationRuntimeService.locationService.getLocationEnabled();
-    HaLocationRuntimeService.refreshZones(false);
     HaLocationRuntimeService.refreshCurrentLocation(reason);
   }
 
@@ -105,8 +87,10 @@ export class HaLocationRuntimeService {
     return HaLocationRuntimeService.running;
   }
 
-  private static shouldUseContinuousLocation(snapshot: LocationRuntimeSnapshot): boolean {
-    return snapshot.locationSentMode === 'exact' && snapshot.flags.accurateLocationEnabled;
+  private static shouldUseBackgroundRuntime(snapshot: LocationRuntimeSnapshot): boolean {
+    return snapshot.flags.locationBackgroundEnabled &&
+      snapshot.locationSentMode === 'exact' &&
+      snapshot.flags.accurateLocationEnabled;
   }
 
   private static startEnabledWatch(): void {
@@ -169,7 +153,6 @@ export class HaLocationRuntimeService {
         if (location) {
           HaLocationRuntimeService.currentZoneName = LocationSensorCoordinator.currentZoneName(location, zones);
         }
-        HaLocationRuntimeService.refreshGeofences();
         if (syncAfterRefresh) {
           HaLocationRuntimeService.syncSensors('zones_refreshed');
         }
@@ -178,44 +161,6 @@ export class HaLocationRuntimeService {
       .finally((): void => {
         HaLocationRuntimeService.zonesRefreshing = false;
       });
-  }
-
-  private static refreshGeofences(): void {
-    const snapshot = HaLocationRuntimeService.snapshot();
-    if (!SensorRuntimePresenter.hasAnyLocationSensorEnabled(snapshot.flags) ||
-      HaLocationRuntimeService.zones.length === 0 ||
-      HaLocationRuntimeService.geofenceRefreshing) {
-      return;
-    }
-    HaLocationRuntimeService.geofenceRefreshing = true;
-    HaLocationRuntimeService.locationService.refreshGeofences(
-      HaLocationRuntimeService.context as common.Context,
-      HaLocationRuntimeService.zones,
-      (transition: HarmonyGeofenceTransition): void => {
-        HaLocationRuntimeService.handleGeofenceTransition(transition);
-      }
-    ).then((status: HarmonyGeofenceStatus): void => {
-      HaLocationRuntimeService.setLocationGeofenceStatus(status.summary);
-    }).catch((err: Error | string | number | boolean | Object): void => {
-      HaLocationRuntimeService.setLocationGeofenceStatus(`geofence_error:${HaLocationRuntimeService.stringifyError(err)}`);
-    }).finally((): void => {
-      HaLocationRuntimeService.geofenceRefreshing = false;
-    });
-  }
-
-  static handleGeofenceWant(context: common.Context): void {
-    HaLocationRuntimeService.context = context;
-    HaLocationRuntimeService.ensureRunning(context, 'geofence_want');
-  }
-
-  private static handleGeofenceTransition(transition: HarmonyGeofenceTransition): void {
-    if (transition.event === 'geofence_enter' || transition.event === 'geofence_dwell') {
-      HaLocationRuntimeService.currentZoneName = transition.zone.name;
-    } else if (transition.event === 'geofence_exit' &&
-      HaLocationRuntimeService.currentZoneName === transition.zone.name) {
-      HaLocationRuntimeService.currentZoneName = '';
-    }
-    HaLocationRuntimeService.refreshCurrentLocation(transition.event);
   }
 
   private static syncSensors(reason: string): void {
@@ -239,7 +184,7 @@ export class HaLocationRuntimeService {
       bearerTypesEnabled: preferences.bearerTypesEnabled,
       lastUpdateTriggerEnabled: preferences.lastUpdateTriggerEnabled,
       locationBackgroundEnabled: preferences.locationBackgroundEnabled && HaLocationRuntimeService.running,
-      zoneBackgroundEnabled: preferences.zoneBackgroundEnabled,
+      zoneBackgroundEnabled: false,
       accurateLocationEnabled: preferences.accurateLocationEnabled,
       directSensorIds: preferences.directSensorIds
     };

--- a/entry/src/main/ets/features/sensors/SensorRuntimeBridgeService.ets
+++ b/entry/src/main/ets/features/sensors/SensorRuntimeBridgeService.ets
@@ -10,7 +10,7 @@ export interface SensorRuntimeBridgeState {
   sensorPluggedTypeEnabled: boolean;
   sensorBearerTypesEnabled: boolean;
   sensorLastUpdateTriggerEnabled: boolean;
-  sensorLocationEnabled: boolean;
+  sensorLocationBackgroundEnabled: boolean;
   sensorZoneBackgroundEnabled: boolean;
   sensorAccurateLocationEnabled: boolean;
   sensorDirectEnabledJson: string;
@@ -29,7 +29,7 @@ export class SensorRuntimeBridgeService {
       pluggedTypeEnabled: state.sensorPluggedTypeEnabled,
       bearerTypesEnabled: state.sensorBearerTypesEnabled,
       lastUpdateTriggerEnabled: state.sensorLastUpdateTriggerEnabled,
-      locationBackgroundEnabled: state.sensorLocationEnabled,
+      locationBackgroundEnabled: state.sensorLocationBackgroundEnabled,
       zoneBackgroundEnabled: state.sensorZoneBackgroundEnabled,
       accurateLocationEnabled: state.sensorAccurateLocationEnabled,
       directSensorIds: SensorRuntimePresenter.directSensorIdsFromJson(state.sensorDirectEnabledJson)
@@ -42,7 +42,7 @@ export class SensorRuntimeBridgeService {
     state.sensorPluggedTypeEnabled = flags.pluggedTypeEnabled;
     state.sensorBearerTypesEnabled = flags.bearerTypesEnabled;
     state.sensorLastUpdateTriggerEnabled = flags.lastUpdateTriggerEnabled;
-    state.sensorLocationEnabled = flags.locationBackgroundEnabled;
+    state.sensorLocationBackgroundEnabled = flags.locationBackgroundEnabled;
     state.sensorZoneBackgroundEnabled = flags.zoneBackgroundEnabled;
     state.sensorAccurateLocationEnabled = flags.accurateLocationEnabled;
     state.sensorDirectEnabledJson = SensorRuntimePresenter.directSensorIdsToJson(flags.directSensorIds);

--- a/entry/src/main/ets/features/sensors/SensorRuntimeService.ets
+++ b/entry/src/main/ets/features/sensors/SensorRuntimeService.ets
@@ -89,13 +89,18 @@ export class SensorRuntimeService {
   }
 
   startLocationSensorsIfNeeded(callbacks: SensorRuntimeCallbacks): void {
-    HaLocationRuntimeService.ensureRunning(callbacks.context(), 'location_runtime_start');
+    this.syncBackgroundLocationRuntime(callbacks, 'location_runtime_start');
     this.latestLocationEnabled = this.locationService.getLocationEnabled();
     this.locationService.startLocationEnabledWatch((enabled: boolean): void => {
       this.latestLocationEnabled = enabled;
       HaLocationRuntimeService.setLocationEnabled(enabled);
       this.syncPublicSensors('location_enabled_changed', callbacks);
     });
+    if (this.shouldUseBackgroundLocationRuntime(callbacks)) {
+      this.locationService.stopLocationWatch();
+      this.stopLocationGeofences(callbacks);
+      return;
+    }
     if (!this.needsForegroundLocation(callbacks.snapshot().flags)) {
       return;
     }
@@ -149,7 +154,7 @@ export class SensorRuntimeService {
           pluggedTypeEnabled: flags.pluggedTypeEnabled,
           bearerTypesEnabled: flags.bearerTypesEnabled,
           lastUpdateTriggerEnabled: flags.lastUpdateTriggerEnabled,
-          locationBackgroundEnabled: true,
+          locationBackgroundEnabled: false,
           zoneBackgroundEnabled: false,
           accurateLocationEnabled: true,
           directSensorIds: flags.directSensorIds
@@ -157,7 +162,6 @@ export class SensorRuntimeService {
         this.latestLocationEnabled = this.locationService.getLocationEnabled();
         this.startLocationSensorsIfNeeded(callbacks);
         this.refreshLocationZones(false, callbacks);
-        HaLocationRuntimeService.ensureRunning(callbacks.context(), reason);
         this.syncCurrentLocation(reason, callbacks, onFinished);
       })
       .catch((): void => {
@@ -250,7 +254,7 @@ export class SensorRuntimeService {
           pluggedTypeEnabled: flags.pluggedTypeEnabled,
           bearerTypesEnabled: flags.bearerTypesEnabled,
           lastUpdateTriggerEnabled: flags.lastUpdateTriggerEnabled,
-          locationBackgroundEnabled: flags.locationBackgroundEnabled,
+          locationBackgroundEnabled: value === 'exact' ? flags.locationBackgroundEnabled : false,
           zoneBackgroundEnabled: value === 'zone',
           accurateLocationEnabled: value === 'exact',
           directSensorIds: flags.directSensorIds
@@ -258,7 +262,6 @@ export class SensorRuntimeService {
         this.latestLocationEnabled = this.locationService.getLocationEnabled();
         this.startLocationSensorsIfNeeded(callbacks);
         this.refreshLocationZones(false, callbacks);
-        HaLocationRuntimeService.ensureRunning(callbacks.context(), 'location_sent_mode_changed');
         this.syncCurrentLocation('location_sent_mode_changed', callbacks, onChanged);
       });
   }
@@ -284,12 +287,11 @@ export class SensorRuntimeService {
         accurateLocationEnabled: flags.accurateLocationEnabled,
         directSensorIds: flags.directSensorIds
       });
+      HaLocationRuntimeService.stop();
       if (!this.needsForegroundLocation(callbacks.snapshot().flags)) {
         this.stopLocationRuntime(callbacks);
-        HaLocationRuntimeService.stop();
-      } else if (!this.hasAnyLocationSensorEnabled(callbacks.snapshot().flags)) {
-        this.stopLocationGeofences(callbacks);
-        HaLocationRuntimeService.stop();
+      } else {
+        this.startLocationSensorsIfNeeded(callbacks);
       }
       callbacks.refreshLiveRows();
       onChanged?.();
@@ -880,7 +882,6 @@ export class SensorRuntimeService {
     this.latestLocationEnabled = this.locationService.getLocationEnabled();
     this.startLocationSensorsIfNeeded(callbacks);
     this.refreshLocationZones(false, callbacks);
-    HaLocationRuntimeService.ensureRunning(callbacks.context(), reason);
     callbacks.refreshLiveRows();
     onChanged?.();
     this.syncPublicSensors('sensor_preferences_changed', callbacks);
@@ -924,7 +925,7 @@ export class SensorRuntimeService {
       this.stopLocationRuntime(callbacks);
       return;
     }
-    if (!this.hasAnyLocationSensorEnabled(callbacks.snapshot().flags)) {
+    if (!callbacks.snapshot().flags.zoneBackgroundEnabled) {
       this.stopLocationGeofences(callbacks);
     }
   }
@@ -951,14 +952,16 @@ export class SensorRuntimeService {
   }
 
   private refreshLocationGeofences(callbacks: SensorRuntimeCallbacks): void {
-    if (!this.hasAnyLocationSensorEnabled(callbacks.snapshot().flags) ||
-      this.locationZones.length === 0 ||
-      this.geofenceRefreshing) {
+    if (!callbacks.snapshot().flags.zoneBackgroundEnabled ||
+      this.locationZones.length === 0) {
+      this.stopLocationGeofences(callbacks);
+      return;
+    }
+    if (this.geofenceRefreshing) {
       return;
     }
     this.geofenceRefreshing = true;
     this.locationService.refreshGeofences(
-      callbacks.context(),
       this.locationZones,
       (transition: HarmonyGeofenceTransition): void => {
         this.handleGeofenceTransition(transition, callbacks);
@@ -970,6 +973,21 @@ export class SensorRuntimeService {
     }).finally((): void => {
       this.geofenceRefreshing = false;
     });
+  }
+
+  private syncBackgroundLocationRuntime(callbacks: SensorRuntimeCallbacks, reason: string): void {
+    if (this.shouldUseBackgroundLocationRuntime(callbacks)) {
+      HaLocationRuntimeService.ensureRunning(callbacks.context(), reason);
+      return;
+    }
+    HaLocationRuntimeService.stop();
+  }
+
+  private shouldUseBackgroundLocationRuntime(callbacks: SensorRuntimeCallbacks): boolean {
+    const snapshot = callbacks.snapshot();
+    return snapshot.flags.locationBackgroundEnabled &&
+      snapshot.locationSentMode === 'exact' &&
+      snapshot.flags.accurateLocationEnabled;
   }
 
   private handleGeofenceTransition(

--- a/entry/src/main/ets/services/HarmonyLocationService.ets
+++ b/entry/src/main/ets/services/HarmonyLocationService.ets
@@ -5,8 +5,6 @@ import common from '@ohos.app.ability.common';
 import geoLocationManager from '@ohos.geoLocationManager';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import type { Permissions } from '@ohos.abilityAccessCtrl';
-import type { WantAgent } from '@ohos.wantAgent';
-import { wantAgent } from '@kit.AbilityKit';
 
 export interface HarmonyLocationSnapshot {
   latitude: number;
@@ -51,7 +49,6 @@ export interface HarmonyGeofenceStatus {
 const GEOFENCE_EXPIRATION_MS = 24 * 60 * 60 * 1000;
 const DOMAIN = 0x0000;
 const TAG = 'HALocationService';
-export const HARMONY_GEOFENCE_ACTION = 'ha.companion.location.GEOFENCE';
 
 interface PermissionRequestError {
   code?: number;
@@ -61,8 +58,6 @@ export class HarmonyLocationService {
   private locationCallback: ((location: geoLocationManager.Location) => void) | undefined = undefined;
   private enabledCallback: ((enabled: boolean) => void) | undefined = undefined;
   private geofenceIds: number[] = [];
-  private geofenceRequests: geoLocationManager.GeofenceRequest[] = [];
-  private geofenceWantAgent: WantAgent | undefined = undefined;
 
   async requestLocationPermission(context: common.Context): Promise<boolean> {
     return this.requestPreciseLocationPermission(context);
@@ -222,7 +217,6 @@ export class HarmonyLocationService {
   }
 
   async refreshGeofences(
-    context: common.Context,
     zones: HarmonyLocationZone[],
     onTransition: (transition: HarmonyGeofenceTransition) => void
   ): Promise<HarmonyGeofenceStatus> {
@@ -252,10 +246,6 @@ export class HarmonyLocationService {
       };
     }
     const maxGeofences = Math.min(zones.length, 100);
-    const systemStatus = await this.refreshSystemGeofences(context, zones, maxGeofences);
-    if (systemStatus.active) {
-      return systemStatus;
-    }
     try {
       for (let i = 0; i < maxGeofences; i++) {
         const zone = zones[i];
@@ -302,18 +292,6 @@ export class HarmonyLocationService {
   }
 
   async stopGeofences(): Promise<void> {
-    const requests = this.geofenceRequests;
-    const agent = this.geofenceWantAgent;
-    this.geofenceRequests = [];
-    this.geofenceWantAgent = undefined;
-    if (agent) {
-      for (let i = 0; i < requests.length; i++) {
-        try {
-          geoLocationManager.off('gnssFenceStatusChange', requests[i], agent);
-        } catch (_) {
-        }
-      }
-    }
     const ids = this.geofenceIds;
     this.geofenceIds = [];
     for (let i = 0; i < ids.length; i++) {
@@ -404,64 +382,6 @@ export class HarmonyLocationService {
       }
     }
     return false;
-  }
-
-  private async refreshSystemGeofences(
-    context: common.Context,
-    zones: HarmonyLocationZone[],
-    maxGeofences: number
-  ): Promise<HarmonyGeofenceStatus> {
-    let agent: WantAgent;
-    try {
-      const abilityContext = context as common.UIAbilityContext;
-      agent = await wantAgent.getWantAgent({
-        wants: [{
-          bundleName: abilityContext.abilityInfo.bundleName,
-          abilityName: abilityContext.abilityInfo.name,
-          action: HARMONY_GEOFENCE_ACTION
-        }],
-        actionType: wantAgent.OperationType.START_ABILITY,
-        requestCode: 735003,
-        actionFlags: [wantAgent.WantAgentFlags.UPDATE_PRESENT_FLAG]
-      });
-    } catch (err) {
-      return {
-        active: false,
-        summary: `system_geofence_agent_failed:${HarmonyLocationService.stringifyError(err)}`,
-        registeredCount: 0
-      };
-    }
-
-    try {
-      for (let i = 0; i < maxGeofences; i++) {
-        const zone = zones[i];
-        const request: geoLocationManager.GeofenceRequest = {
-          scenario: geoLocationManager.LocationRequestScenario.DAILY_LIFE_SERVICE,
-          geofence: {
-            latitude: zone.latitude,
-            longitude: zone.longitude,
-            coordinateSystemType: geoLocationManager.CoordinateSystemType.WGS84,
-            radius: Math.max(zone.radius, 100),
-            expiration: GEOFENCE_EXPIRATION_MS
-          }
-        };
-        geoLocationManager.on('gnssFenceStatusChange', request, agent);
-        this.geofenceRequests.push(request);
-      }
-      this.geofenceWantAgent = agent;
-      return {
-        active: this.geofenceRequests.length > 0,
-        summary: `system_active:${this.geofenceRequests.length}`,
-        registeredCount: this.geofenceRequests.length
-      };
-    } catch (err) {
-      await this.stopGeofences();
-      return {
-        active: false,
-        summary: `system_geofence_failed:${HarmonyLocationService.stringifyError(err)}`,
-        registeredCount: 0
-      };
-    }
   }
 
   private static geofenceEventName(event: geoLocationManager.GeofenceTransitionEvent): string {


### PR DESCRIPTION
## Summary
- Remove the geofence WantAgent wake-up path so geofence transitions no longer bring the app foreground for reporting.
- Keep geofence reporting scoped to the active sensor runtime.
- Limit the long-running background location runtime to exact location sharing with background location enabled.

## Related Issue
Fixes #3

## Verification

- HarmonyOS version: Not device-tested in this environment
- Device model: Not device-tested in this environment
- API version: Not device-tested in this environment

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [ ] User-facing behavior has been verified on a HarmonyOS device or emulator.
- [ ] UI changes have screenshots or recordings when applicable.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes
- Verified with `git diff --check`.
- Verified with `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\build.ps1 debug hap`.