### PR TITLE
Disable release obfuscation by default

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -122,7 +122,7 @@ HACompanionNext/
 │
 ├─ entry/
 │  ├─ build-profile.json5
-│  │  Entry module build configuration, including release obfuscation settings.
+│  │  Entry module build configuration. Release obfuscation is disabled by default.
 │  ├─ obfuscation-rules.txt
 │  │  ArkTS obfuscation rules.
 │  └─ src/main/
@@ -347,7 +347,7 @@ Runtime code reads the bundled HarmonyOS version through `AppVersionService`. Se
 - Push Kit is not integrated for now; remote push features should be revisited only after the required entity qualification, AppGallery distribution path, and platform service configuration are clear.
 - The project does not plan to publish to Huawei AppGallery under an individual developer account; it is currently better treated as an open-source implementation, development build, and real-device validation project.
 - NFC, speech, background tasks, notifications, location, and service cards need more real-device coverage.
-- Release obfuscation is enabled, but keep rules for external Home Assistant protocol fields must be maintained carefully to avoid breaking wire formats.
+- Release obfuscation is disabled by default to avoid rewriting external Home Assistant protocol fields and breaking wire formats.
 - HarmonyOS NEXT and its SDK are still evolving, so API behavior may change between versions.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ HACompanionNext/
 │
 ├─ entry/
 │  ├─ build-profile.json5
-│  │  entry 模块构建配置。当前包含 release obfuscation 配置。
+│  │  entry 模块构建配置。release 混淆当前默认关闭。
 │  ├─ obfuscation-rules.txt
 │  │  ArkTS 混淆规则。
 │  └─ src/main/
@@ -347,7 +347,7 @@ git ls-files -v build-profile.json5
 - Push Kit 暂不接入；涉及远程推送的能力需要等合适的主体资质、应用市场分发条件和平台服务配置明确后再评估。
 - 项目不计划以个人身份上架华为应用市场，当前更适合作为开源实现、开发构建和真机验证项目。
 - NFC、语音、后台任务、通知、定位、服务卡片等平台能力需要更多真机覆盖。
-- release 混淆已开启，但涉及 Home Assistant 外部协议字段时需要持续维护 keep 规则，避免破坏 wire format。
+- release 混淆当前默认关闭，避免 Home Assistant 外部协议字段被改写并破坏 wire format。
 - HarmonyOS NEXT 平台和 SDK 仍在演进，部分 API 行为可能随版本变化。
 
 ## 许可证

--- a/entry/build-profile.json5
+++ b/entry/build-profile.json5
@@ -13,7 +13,7 @@
       "arkOptions": {
         "obfuscation": {
           "ruleOptions": {
-            "enable": true,
+            "enable": false,
             "files": [
               "./obfuscation-rules.txt"
             ]


### PR DESCRIPTION
## Summary
- Disable release obfuscation by default for the entry module.
- Update Chinese and English README notes to document the default release obfuscation behavior.
- Avoid rewriting Home Assistant protocol field names in release builds.

## Related Issue
Fixes #37

## Verification

- HarmonyOS version: Not applicable
- Device model: Not applicable
- API version: Not applicable

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [ ] User-facing behavior has been verified on a HarmonyOS device or emulator.
- [ ] UI changes have screenshots or recordings when applicable.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes
- Verified with `git diff --check`.