### PR TITLE
Fix dashboard connection wait on foreground

### DIFF
--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -678,6 +678,13 @@ export struct AppRuntimeHost {
     }
   }
 
+  handleDashboardForegroundConnectionWait(): void {
+    if (this.dashboardInsecureBlocked || this.step !== AppRoute.DASHBOARD || this.dashboardConnectionErrorVisible) {
+      return;
+    }
+    this.scheduleDashboardConnectionWait();
+  }
+
   handleDashboardConnectionStatus(connected: boolean): void {
     if (connected) {
       this.dashboardFrontendConnected = true;
@@ -734,11 +741,19 @@ export struct AppRuntimeHost {
     this.dashboardConnectionWaitToken = token;
     setTimeout((): void => {
       if (this.dashboardConnectionWaitToken !== token || this.dashboardFrontendConnected ||
-        this.shouldSkipDashboardConnectionWait()) {
+        !this.isAppActive() || this.shouldSkipDashboardConnectionWait()) {
         return;
       }
       this.dashboardConnectionErrorVisible = true;
     }, DASHBOARD_CONNECTION_WAIT_MS);
+  }
+
+  private cancelDashboardConnectionWait(): void {
+    this.dashboardConnectionWaitToken += 1;
+  }
+
+  private isAppActive(): boolean {
+    return AppStorage.get<boolean>('appActive') ?? false;
   }
 
   private shouldSkipDashboardConnectionWait(): boolean {
@@ -1169,9 +1184,17 @@ export struct AppRuntimeHost {
 
   isIgnoringAppLockTransitions(): boolean { return this.appLockAuthPending || this.appUnlocking || Date.now() < this.appLockIgnoreTransitionsUntil; }
 
-  private onAppForegroundTick(): void { AppLifecycleRuntimeService.onForeground(this, AppRuntimeCallbackFactory.lifecycle(this)); }
+  private onAppForegroundTick(): void {
+    AppLifecycleRuntimeService.onForeground(this, AppRuntimeCallbackFactory.lifecycle(this));
+    if (this.step === AppRoute.DASHBOARD && !this.appLocked) {
+      this.handleDashboardForegroundConnectionWait();
+    }
+  }
 
-  private onAppBackgroundTick(): void { AppLifecycleRuntimeService.onBackground(this, AppRuntimeCallbackFactory.lifecycle(this)); }
+  private onAppBackgroundTick(): void {
+    AppLifecycleRuntimeService.onBackground(this, AppRuntimeCallbackFactory.lifecycle(this));
+    this.cancelDashboardConnectionWait();
+  }
 
   private onAppConfigurationTick(): void { AppLifecycleRuntimeService.onConfiguration(this, AppRuntimeCallbackFactory.lifecycle(this)); }
 


### PR DESCRIPTION
﻿## Summary
- Cancel pending dashboard connection error timers when the app goes to background.
- Prevent background timers from showing the dashboard connection error while the app is inactive.
- Restart the foreground connection wait without clearing an already connected dashboard state.

Root cause: the dashboard connection wait timer could continue after the app entered the background, so returning later could surface a stale connection error even when the WebView had not actually failed in the foreground.

## Related Issue
None

## Verification

- HarmonyOS version: Not device-tested in this session
- Device model: Not device-tested in this session
- API version: Not device-tested in this session

## Screenshots or Recordings
Not captured in this session.

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [ ] User-facing behavior has been verified on a HarmonyOS device or emulator.
- [ ] UI changes have screenshots or recordings when applicable.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes
- Verified with `git diff --check`.
- Verified with `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\build.ps1 debug hap`.
- The build warnings are existing syscap/deprecation warnings outside this dashboard connection wait change.
