### PR TITLE
Add media card volume controls

### DIFF
--- a/entry/src/main/ets/services/HaEntityParser.ets
+++ b/entry/src/main/ets/services/HaEntityParser.ets
@@ -239,6 +239,12 @@ export class HaEntityParser {
     if (action === 'media_previous') {
       return 'media_previous_track';
     }
+    if (action === 'media_volume_down') {
+      return 'volume_down';
+    }
+    if (action === 'media_volume_up') {
+      return 'volume_up';
+    }
     return '';
   }
 

--- a/entry/src/main/ets/widget/pages/HarmonyMediaServiceCard.ets
+++ b/entry/src/main/ets/widget/pages/HarmonyMediaServiceCard.ets
@@ -181,6 +181,10 @@ struct HarmonyMediaServiceCard {
       this.detailContentArea()
 
       Row() {
+        this.controlButton('volume_down', 'minus')
+        this.controlGap()
+        this.controlButton('volume_up', 'plus')
+        this.controlGap()
         this.controlButton('previous', 'previous')
         this.controlGap()
         this.playPauseButton()


### PR DESCRIPTION
﻿## Summary

- Add volume down and volume up controls to the Harmony media service card.
- Map the new widget events to Home Assistant `media_player.volume_down` and `media_player.volume_up` services.

## Related Issue

None.

## Verification

- HarmonyOS version: Not verified
- Device model: Not verified
- API version: Not verified

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [ ] User-facing behavior has been verified on a HarmonyOS device or emulator.
- [ ] UI changes have screenshots or recordings when applicable.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes

This change reuses existing system plus/minus icons and does not add new resources.
