### PR TITLE
Fix dashboard home network routing

### DIFF
--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -617,6 +617,7 @@ export struct AppRuntimeHost {
     this.restoreInstanceAppSettingsState()
       .then((): Promise<void> => this.loadSensorStates())
       .then((): void => this.refreshSensorLiveRows())
+      .then((): Promise<void> => this.refreshHomeNetworkStatusNow('', false))
       .catch((): void => {})
       .finally((): void => {
         AppLifecycleRuntimeService.aboutToAppear(this, AppRuntimeCallbackFactory.lifecycle(this));


### PR DESCRIPTION
## Summary
- Refresh home network status after restoring instance app settings on first app appearance.
- Keeps dashboard routing decisions aligned with restored home network preferences before lifecycle startup continues.

## Related Issue
N/A

## Verification
- HarmonyOS version: 6.1.0.117(SP6C00E115R3P5)
- Device model: ADY-AL00
- API version: 23
- Checked with: `git diff --check`

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [ ] User-facing behavior has been verified on a HarmonyOS device or emulator.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes
- No screenshots attached; this is a routing state timing fix with no direct visual change.