### PR TITLE
Add report issue settings action

### DIFF
--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -2412,6 +2412,16 @@ export struct AppRuntimeHost {
   openAssistSettings(): void { this.step = 13; }
 
   handleSettingsAction(actionId: string): void {
+    if (actionId === 'report_issue') {
+      const url = 'https://github.com/xiasi0/ha-companion-harmonyos/issues';
+      (this.context() as common.UIAbilityContext).startAbility({
+        action: 'ohos.want.action.viewData',
+        uri: url
+      }).catch((): void => {
+        this.message = url;
+      });
+      return;
+    }
     if (actionId.startsWith('open_server_detail:')) {
       this.openServerSettingsFor(actionId.substring('open_server_detail:'.length));
       return;

--- a/entry/src/main/ets/features/settings/SettingsNavigationRoutes.ets
+++ b/entry/src/main/ets/features/settings/SettingsNavigationRoutes.ets
@@ -261,6 +261,10 @@ export function openSettingsNavigationItem(
   actions: SettingsRuntimeActions,
   onSynced?: (target: SettingsNavSyncTarget) => void
 ): void {
+  if (item.actionId === 'report_issue') {
+    actions.onAction(item.actionId);
+    return;
+  }
   actions.onOpen(item);
   if (item.type === SettingsItemType.SWITCH ||
     usesServerEditDialog(item.actionId) ||

--- a/entry/src/main/ets/features/settings/SettingsSectionService.ets
+++ b/entry/src/main/ets/features/settings/SettingsSectionService.ets
@@ -97,7 +97,8 @@ export class SettingsSectionService {
       SettingsSectionService.policySection(input.profile, Localization.t('settings_section_app_info'), [
         SettingsSectionService.capabilityItem(detailSettingsItem('info', Localization.t('settings_app_version'), AppVersionService.versionLabel(), Localization.t('common_available'), Localization.t('settings_app_version_body')), SettingsCapability.APP_INFO),
         SettingsSectionService.capabilityItem(SettingsSectionService.detailActionItem('license', Localization.t('settings_open_source_licenses'), Localization.t('settings_open_source_licenses_summary'), '', '', 'open_source_licenses'), SettingsCapability.APP_INFO),
-        SettingsSectionService.capabilityItem(SettingsSectionService.detailActionItem('privacy', Localization.t('settings_privacy_policy'), Localization.t('settings_privacy_policy_summary'), '', '', 'privacy_policy'), SettingsCapability.APP_INFO)
+        SettingsSectionService.capabilityItem(SettingsSectionService.detailActionItem('privacy', Localization.t('settings_privacy_policy'), Localization.t('settings_privacy_policy_summary'), '', '', 'privacy_policy'), SettingsCapability.APP_INFO),
+        SettingsSectionService.capabilityItem(actionSettingsItem('question', Localization.t('settings_report_issue'), Localization.t('settings_report_issue_summary'), '', 'report_issue'), SettingsCapability.APP_INFO)
       ])
     ];
   }

--- a/entry/src/main/ets/shared/i18n/resources/LocalizationEnUs.ets
+++ b/entry/src/main/ets/shared/i18n/resources/LocalizationEnUs.ets
@@ -208,6 +208,8 @@ export const EN_US: Map<string, string> = new Map<string, string>([
   ['license_harmony_sdk', 'The app is built with HarmonyOS SDK and system capabilities. Related terms follow the agreements bundled with the Huawei developer toolchain.'],
   ['settings_privacy_policy', 'Privacy policy'],
   ['settings_privacy_policy_summary', 'View the Home Assistant privacy policy and Huawei privacy statement'],
+  ['settings_report_issue', 'Report an issue'],
+  ['settings_report_issue_summary', 'Open GitHub to report an issue.'],
   ['privacy_home_assistant_statement', 'Home Assistant privacy statement'],
   ['privacy_huawei_statement', 'Huawei privacy statement'],
   ['capability_companion_layout', 'This device form factor needs separate information architecture, so the companion app entry is kept for now.'],

--- a/entry/src/main/ets/shared/i18n/resources/LocalizationZhCn.ets
+++ b/entry/src/main/ets/shared/i18n/resources/LocalizationZhCn.ets
@@ -208,6 +208,8 @@ export const ZH_CN: Map<string, string> = new Map<string, string>([
   ['license_harmony_sdk', '应用使用 HarmonyOS SDK 和系统能力构建，相关许可和条款以华为开发者工具链随附协议为准。'],
   ['settings_privacy_policy', '隐私政策'],
   ['settings_privacy_policy_summary', '查看 Home Assistant 隐私政策和华为隐私声明'],
+  ['settings_report_issue', '问题报告'],
+  ['settings_report_issue_summary', '前往 GitHub 提交问题报告。'],
   ['privacy_home_assistant_statement', 'Home Assistant 隐私声明'],
   ['privacy_huawei_statement', '华为隐私声明'],
   ['capability_companion_layout', '该设备形态需要单独的信息架构，当前保留伴侣应用入口。'],


### PR DESCRIPTION
## Summary

- Add a "Report an issue" action to the App info settings section.
- Open the repository's GitHub issues page through the system browser.
- Add English and Simplified Chinese labels for the new entry.

This gives users a direct route from the app settings to the project's issue tracker without creating a settings detail page.

## Related Issue

N/A

## Verification

- HarmonyOS version: Not tested on device
- Device model: Not tested on device
- API version: Build environment API 23
- Signed Debug HAP build: passed via `scripts/build.ps1 debug hap`

## Screenshots or Recordings

Not captured. Device UI verification is pending.

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [ ] User-facing behavior has been verified on a HarmonyOS device or emulator.
- [ ] UI changes have screenshots or recordings when applicable.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes

The browser launch falls back to displaying the issues URL in the app when the system cannot handle the URL intent.