### PR TITLE
feat: add in-app review prompt

### DIFF
--- a/build-profile.json5
+++ b/build-profile.json5
@@ -5,7 +5,7 @@
     "products": [
       {
         "name": "default",
-        "targetSdkVersion": "6.1.0(23)",
+        "targetSdkVersion": "6.1.1(24)",
         "compatibleSdkVersion": "6.1.0(23)",
         "runtimeOS": "HarmonyOS",
         "buildOption": {

--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -2,6 +2,8 @@
 // It coordinates navigation, server selection, overlays, WebView state, and feature services.
 import common from '@ohos.app.ability.common';
 import web_webview from '@ohos.web.webview';
+import { commentManager } from '@kit.AppGalleryKit';
+import { BusinessError } from '@kit.BasicServicesKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { HaServerItem } from '../models/HaServerItem';
 import { UrlGuardResult } from '../models/UrlGuardResult';
@@ -40,6 +42,7 @@ import { ManagedServer, ServerManager } from '../services/ServerManager';
 import { ServerInstanceStore, ServerRuntimeState } from '../services/ServerInstanceStore';
 import { ServerAuthRepository, ServerAuthSession } from '../services/ServerAuthRepository';
 import { AppSettingsStore } from '../services/AppSettingsStore';
+import { AppReviewPromptService } from '../services/AppReviewPromptService';
 import { ExternalBusService } from '../services/ExternalBusService';
 import { HaConnectionPolicyService } from '../services/HaConnectionPolicyService';
 import { SystemEventService } from '../services/SystemEventService';
@@ -86,6 +89,7 @@ AppStorageDefaults.register();
 const DOMAIN = 0x0000;
 const TAG = 'HACompanion';
 const DASHBOARD_CONNECTION_WAIT_MS = 10000;
+const APP_REVIEW_PROMPT_DELAY_MS = 3000;
 
 function initialRuntimeRoute(): AppRoute {
   const baseUrl = AppStorage.get<string>('haBaseUrl') ?? '';
@@ -245,6 +249,8 @@ export struct AppRuntimeHost {
   private applyingSensorFlags: boolean = false;
   private lastSensorPreferenceKey: string = '';
   private dashboardConnectionWaitToken: number = 0;
+  private appReviewPromptToken: number = 0;
+  private appReviewPromptInFlight: boolean = false;
   private dashboardFrontendConnected: boolean = false;
   @State viewportWidth: number = AppDeviceRuntimeService.defaultViewportWidth();
   @State viewportHeight: number = 0;
@@ -720,12 +726,14 @@ export struct AppRuntimeHost {
       this.dashboardFrontendConnected = true;
       this.dashboardConnectionWaitToken += 1;
       this.dashboardConnectionErrorVisible = false;
+      this.scheduleAppReviewPrompt();
       return;
     }
     if (this.dashboardInsecureBlocked || this.step !== AppRoute.DASHBOARD) {
       return;
     }
     this.dashboardFrontendConnected = false;
+    this.cancelAppReviewPrompt();
     this.scheduleDashboardConnectionWait();
   }
 
@@ -780,6 +788,59 @@ export struct AppRuntimeHost {
 
   private cancelDashboardConnectionWait(): void {
     this.dashboardConnectionWaitToken += 1;
+  }
+
+  private scheduleAppReviewPrompt(): void {
+    AppReviewPromptService.isEligibleAfterDashboardConnection(this.context())
+      .then((eligible: boolean): void => {
+        if (!eligible || !this.canShowAppReviewPrompt()) {
+          return;
+        }
+        const token = this.appReviewPromptToken + 1;
+        this.appReviewPromptToken = token;
+        setTimeout((): void => {
+          if (this.appReviewPromptToken !== token || this.appReviewPromptInFlight || !this.canShowAppReviewPrompt()) {
+            return;
+          }
+          this.appReviewPromptInFlight = true;
+          this.showAppReviewPrompt();
+        }, APP_REVIEW_PROMPT_DELAY_MS);
+      });
+  }
+
+  private showAppReviewPrompt(): void {
+    try {
+      const context = this.getUIContext().getHostContext() as common.UIAbilityContext;
+      commentManager.showCommentDialog(context)
+        .then((): void => this.finishAppReviewPrompt())
+        .catch((error: BusinessError): void => this.finishAppReviewPrompt(error));
+    } catch (error) {
+      this.finishAppReviewPrompt(error as BusinessError);
+    }
+  }
+
+  private finishAppReviewPrompt(error?: BusinessError): void {
+    if (error && error.code !== 1021500007 && error.code !== 1021500008 && error.code !== 1021500009) {
+      this.appReviewPromptInFlight = false;
+      return;
+    }
+    AppReviewPromptService.markPromptHandled(this.context())
+      .then((): void => {
+        this.appReviewPromptInFlight = false;
+      });
+  }
+
+  private cancelAppReviewPrompt(): void {
+    this.appReviewPromptToken += 1;
+  }
+
+  private canShowAppReviewPrompt(): boolean {
+    return this.step === AppRoute.DASHBOARD &&
+      this.dashboardFrontendConnected &&
+      !this.dashboardInsecureBlocked &&
+      this.isAppActive() &&
+      !this.appLocked &&
+      !this.dashboardConnectionErrorVisible;
   }
 
   private isAppActive(): boolean {
@@ -1148,6 +1209,7 @@ export struct AppRuntimeHost {
       this.refreshCurrentLocationForDiagnostics('sensor_settings_opened');
     } else {
       this.dashboardConnectionWaitToken += 1;
+      this.cancelAppReviewPrompt();
       this.dashboardConnectionErrorVisible = false;
     }
   }
@@ -1346,6 +1408,7 @@ export struct AppRuntimeHost {
   private onAppBackgroundTick(): void {
     AppLifecycleRuntimeService.onBackground(this, AppRuntimeCallbackFactory.lifecycle(this));
     this.cancelDashboardConnectionWait();
+    this.cancelAppReviewPrompt();
   }
 
   private onAppConfigurationTick(): void { AppLifecycleRuntimeService.onConfiguration(this, AppRuntimeCallbackFactory.lifecycle(this)); }

--- a/entry/src/main/ets/services/AppReviewPromptService.ets
+++ b/entry/src/main/ets/services/AppReviewPromptService.ets
@@ -1,0 +1,72 @@
+import common from '@ohos.app.ability.common';
+import preferences from '@ohos.data.preferences';
+
+export class AppReviewPromptService {
+  private static readonly PREFERENCES_NAME: string = 'ha_app_review_prompt';
+  private static readonly LAST_ACTIVE_DATE: string = 'last_active_date';
+  private static readonly ACTIVE_DAY_STREAK: string = 'active_day_streak';
+  private static readonly ATTEMPTED: string = 'attempted';
+  private static readonly REQUIRED_ACTIVE_DAY_STREAK: number = 3;
+
+  static async isEligibleAfterDashboardConnection(context: common.Context): Promise<boolean> {
+    try {
+      const pref = await preferences.getPreferences(context, AppReviewPromptService.PREFERENCES_NAME);
+      if (AppReviewPromptService.booleanField(await pref.get(AppReviewPromptService.ATTEMPTED, false))) {
+        return false;
+      }
+
+      const now = new Date();
+      const today = AppReviewPromptService.dateKey(now);
+      const lastActiveDate = AppReviewPromptService.stringField(
+        await pref.get(AppReviewPromptService.LAST_ACTIVE_DATE, '')
+      );
+      let streak = AppReviewPromptService.numberField(
+        await pref.get(AppReviewPromptService.ACTIVE_DAY_STREAK, 0)
+      );
+      if (lastActiveDate === today) {
+        return streak >= AppReviewPromptService.REQUIRED_ACTIVE_DAY_STREAK;
+      }
+
+      streak = lastActiveDate === AppReviewPromptService.previousDateKey(now) ? streak + 1 : 1;
+      await pref.put(AppReviewPromptService.LAST_ACTIVE_DATE, today);
+      await pref.put(AppReviewPromptService.ACTIVE_DAY_STREAK, streak);
+      await pref.flush();
+      return streak >= AppReviewPromptService.REQUIRED_ACTIVE_DAY_STREAK;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static async markPromptHandled(context: common.Context): Promise<void> {
+    try {
+      const pref = await preferences.getPreferences(context, AppReviewPromptService.PREFERENCES_NAME);
+      await pref.put(AppReviewPromptService.ATTEMPTED, true);
+      await pref.flush();
+    } catch (_) {
+    }
+  }
+
+  private static dateKey(date: Date): string {
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
+  }
+
+  private static previousDateKey(date: Date): string {
+    const previous = new Date(date.getTime());
+    previous.setDate(previous.getDate() - 1);
+    return AppReviewPromptService.dateKey(previous);
+  }
+
+  private static booleanField(value: preferences.ValueType): boolean {
+    return value === true;
+  }
+
+  private static numberField(value: preferences.ValueType): number {
+    return typeof value === 'number' ? value : 0;
+  }
+
+  private static stringField(value: preferences.ValueType): string {
+    return typeof value === 'string' ? value : '';
+  }
+}

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -21,7 +21,7 @@ $devecoHome = if ($env:DEVECO_STUDIO_HOME) { $env:DEVECO_STUDIO_HOME } else { 'D
 $hvigorw = if ($env:DEVECO_HVIGORW) { $env:DEVECO_HVIGORW } else { Join-Path $devecoHome 'tools\hvigor\bin\hvigorw.bat' }
 $devecoSdk = if ($env:DEVECO_SDK_HOME) { $env:DEVECO_SDK_HOME } else { Join-Path $devecoHome 'sdk' }
 $devecoJavaHome = if ($env:DEVECO_JAVA_HOME) { $env:DEVECO_JAVA_HOME } else { Join-Path $devecoHome 'jbr' }
-$targetSdkVersion = '6.1.0(23)'
+$targetSdkVersion = '6.1.1(24)'
 $compatibleSdkVersion = '6.1.0(23)'
 $profileSdkChanged = $false
 


### PR DESCRIPTION
## Summary

- Add a three-day active-use gate for the HarmonyOS in-app review prompt.
- Show the AppGallery review dialog only while the dashboard is connected and visible.
- Target API 24 while retaining API 23 as the installation compatibility floor.

## Impact

Eligible users are prompted once for feedback after sustained use without excluding API 23 devices.

## Validation

- `hvigorw.bat --no-daemon --mode module -p module=entry assembleHap`