### PR TITLE
fix(nfc): validate tag technology

### DIFF
--- a/entry/src/main/ets/features/nfc/NfcTagReaderService.ets
+++ b/entry/src/main/ets/features/nfc/NfcTagReaderService.ets
@@ -23,7 +23,7 @@ export class NfcTagReaderService {
     } catch (_) {
       return false;
     }
-    if (!tagInfo) {
+    if (!tagInfo || !Array.isArray(tagInfo.technology) || tagInfo.technology.length === 0) {
       return false;
     }
     NfcTagReaderService.reading = true;


### PR DESCRIPTION
## Summary
- Reject NFC tags with missing or empty technology metadata before starting a read.

## Validation
- `git diff --check` 
- Verified on a physical device by the author