### PR TITLE
fix(auth): handle external token refresh failures

### DIFF
--- a/entry/src/main/ets/app/AppRuntimeCallbackFactory.ets
+++ b/entry/src/main/ets/app/AppRuntimeCallbackFactory.ets
@@ -11,7 +11,7 @@ import { SensorRuntimeFlags } from '../features/sensors/SensorRuntimePresenter';
 import { DashboardRuntimeCallbacks } from '../features/dashboard/DashboardRuntimeService';
 import { RegistrationRuntimeCallbacks } from '../features/registration/RegistrationRuntimeService';
 import { AuthFlowRuntimeCallbacks } from '../features/auth/AuthFlowRuntimeService';
-import { ExternalAuthRuntimeCallbacks } from '../features/auth/ExternalAuthRuntimeService';
+import { ExternalAuthRuntimeCallbacks, ExternalAuthToken } from '../features/auth/ExternalAuthRuntimeService';
 import { DiscoveryFlowRuntimeCallbacks } from '../features/discovery/DiscoveryFlowRuntimeService';
 import { AppLifecycleRuntimeCallbacks } from './AppLifecycleRuntimeService';
 import { AppNavigationRuntimeCallbacks } from './AppNavigationRuntimeService';
@@ -32,7 +32,7 @@ export interface AppRuntimeCallbackTarget {
   updateSettingsServerName(name: string, info: StoredServerInfo): void;
   syncSettingsServerNameToHomeAssistant(name: string, info: StoredServerInfo): void;
   refreshAccessToken(baseUrl: string): Promise<boolean>;
-  loadExternalAuthAccessToken(baseUrl: string, forceRefresh: boolean): Promise<string>;
+  loadExternalAuthAccessToken(baseUrl: string, forceRefresh: boolean): Promise<ExternalAuthToken>;
   syncPublicSensors(reason: string): void;
   refreshHomeNetworkStatus(allowDashboardUrlReload?: boolean): void;
   ensureMobileAppRegistration(reason: string): void;
@@ -159,7 +159,7 @@ export class AppRuntimeCallbackFactory {
       isWebMounted: (): boolean => target.isWebControllerMounted(),
       runScript: (script: string): void => target.tryRunWebScript(script),
       refreshAccessToken: (baseUrl: string): Promise<boolean> => target.refreshAccessToken(baseUrl),
-      loadAccessToken: (baseUrl: string, forceRefresh: boolean): Promise<string> =>
+      loadAccessToken: (baseUrl: string, forceRefresh: boolean): Promise<ExternalAuthToken> =>
         target.loadExternalAuthAccessToken(baseUrl, forceRefresh),
       currentServerInfo: (): StoredServerInfo => target.currentStoredServerInfo(),
       applyServerInfo: (info: StoredServerInfo): void => target.applyStoredServerInfo(info),

--- a/entry/src/main/ets/app/AppRuntimeHost.ets
+++ b/entry/src/main/ets/app/AppRuntimeHost.ets
@@ -13,7 +13,7 @@ import {
   AuthRuntimeService
 } from '../features/auth/AuthRuntimeService';
 import { AuthFlowRuntimeService } from '../features/auth/AuthFlowRuntimeService';
-import { ExternalAuthRuntimeService } from '../features/auth/ExternalAuthRuntimeService';
+import { ExternalAuthRuntimeService, ExternalAuthToken } from '../features/auth/ExternalAuthRuntimeService';
 import { DiscoveryFlowRuntimeService } from '../features/discovery/DiscoveryFlowRuntimeService';
 import { ServerAccountRuntimeService } from '../features/settings/ServerAccountRuntimeService';
 import { SettingsSummaryService } from '../features/settings/SettingsSummaryService';
@@ -1044,7 +1044,7 @@ export struct AppRuntimeHost {
 
   async refreshAccessToken(baseUrl: string): Promise<boolean> { return AuthFlowRuntimeService.refreshAccessToken(this, AppRuntimeCallbackFactory.authFlow(this), baseUrl); }
 
-  async loadExternalAuthAccessToken(baseUrl: string, forceRefresh: boolean): Promise<string> {
+  async loadExternalAuthAccessToken(baseUrl: string, forceRefresh: boolean): Promise<ExternalAuthToken> {
     const context = this.context();
     const activeId = ServerManager.getActiveServerIdSync(context);
     const normalizedBaseUrl = UrlService.normalizeBaseUrl(baseUrl);
@@ -1053,7 +1053,7 @@ export struct AppRuntimeHost {
       targetId = activeId;
     }
     if (targetId.length === 0) {
-      return this.haAccessToken.trim();
+      return { accessToken: '', expiresIn: 0 };
     }
     const session: ServerAuthSession = forceRefresh
       ? await ServerAuthRepository.refreshWithBaseUrl(context, targetId, normalizedBaseUrl)
@@ -1062,10 +1062,11 @@ export struct AppRuntimeHost {
     if (targetId === activeId && StorageService.hasLogin(latestInfo)) {
       AppSessionRuntimeService.applyServerInfoToState(this, latestInfo);
     }
-    if (forceRefresh) {
-      return session.accessToken.trim();
-    }
-    return session.accessToken.trim().length > 0 ? session.accessToken.trim() : latestInfo.accessToken.trim();
+    const accessToken = session.accessToken.trim();
+    const expiresIn = accessToken.length === 0 ? 0 : latestInfo.accessTokenExpiresAt > 0
+      ? Math.max(0, Math.ceil((latestInfo.accessTokenExpiresAt - Date.now()) / 1000))
+      : 1800;
+    return { accessToken, expiresIn };
   }
 
   private hasRegisteredCurrentDevice(): boolean { return RegistrationRuntimeService.hasRegisteredCurrentDevice(this); }

--- a/entry/src/main/ets/features/auth/ExternalAuthRuntimeService.ets
+++ b/entry/src/main/ets/features/auth/ExternalAuthRuntimeService.ets
@@ -15,11 +15,16 @@ export interface ExternalAuthRuntimeState {
   step: AppRoute;
 }
 
+export interface ExternalAuthToken {
+  accessToken: string;
+  expiresIn: number;
+}
+
 export interface ExternalAuthRuntimeCallbacks {
   isWebMounted: () => boolean;
   runScript: (script: string) => void;
   refreshAccessToken: (baseUrl: string) => Promise<boolean>;
-  loadAccessToken: (baseUrl: string, forceRefresh: boolean) => Promise<string>;
+  loadAccessToken: (baseUrl: string, forceRefresh: boolean) => Promise<ExternalAuthToken>;
   currentServerInfo: () => StoredServerInfo;
   applyServerInfo: (info: StoredServerInfo) => void;
   openCompanionSettings: () => void;
@@ -32,12 +37,13 @@ export class ExternalAuthRuntimeService {
     callback: string,
     success: boolean,
     callbacks: ExternalAuthRuntimeCallbacks,
-    token: string = ''
+    token: string = '',
+    expiresIn: number = 0
   ): void {
     if (!callback || !callbacks.isWebMounted()) {
       return;
     }
-    callbacks.runScript(ExternalBusService.buildExternalAuthCallbackScript(callback, success, token));
+    callbacks.runScript(ExternalBusService.buildExternalAuthCallbackScript(callback, success, token, expiresIn));
   }
 
   static sendExternalBusConfigResponse(messageId: number, callbacks: ExternalAuthRuntimeCallbacks): void {
@@ -93,12 +99,12 @@ export class ExternalAuthRuntimeService {
       ExternalAuthRuntimeService.invokeExternalAuthCallback(callback, false, callbacks);
       return;
     }
-    const finish = (accessToken: string): void => {
-      const token = accessToken.trim();
+    const finish = (result: ExternalAuthToken): void => {
+      const token = result.accessToken.trim();
       if (token) {
         state.dashboardAuthProvided = true;
         state.message = Localization.t('external_auth_providing_token');
-        ExternalAuthRuntimeService.invokeExternalAuthCallback(callback, true, callbacks, token);
+        ExternalAuthRuntimeService.invokeExternalAuthCallback(callback, true, callbacks, token, result.expiresIn);
         setTimeout((): void => {
           if (state.step === AppRoute.DASHBOARD && state.dashboardAuthProvided) {
             state.message = Localization.t('dashboard_visible');
@@ -109,8 +115,8 @@ export class ExternalAuthRuntimeService {
       }
     };
     callbacks.loadAccessToken(baseUrl, force)
-      .then((token: string): void => finish(token))
-      .catch((): void => finish(state.haAccessToken));
+      .then((token: ExternalAuthToken): void => finish(token))
+      .catch((): void => finish({ accessToken: '', expiresIn: 0 }));
   }
 
   static handleExternalRevokeAuth(

--- a/entry/src/main/ets/services/AuthService.ets
+++ b/entry/src/main/ets/services/AuthService.ets
@@ -1,7 +1,11 @@
 // Home Assistant OAuth helper for authorization URL and token exchange.
 // Keep OAuth request construction and response validation in this service.
 import { Localization } from '../shared/i18n/Localization';
+import { hilog } from '@kit.PerformanceAnalysisKit';
 import { NetworkHttpMethod, NetworkService } from './NetworkService';
+
+const DOMAIN = 0x0000;
+const TAG = 'HAAuth';
 
 export interface AuthTokenResult {
   accessToken: string;
@@ -100,6 +104,7 @@ export class AuthService {
       });
 
       if (resp.responseCode < 200 || resp.responseCode >= 300) {
+        hilog.warn(DOMAIN, TAG, 'refresh token request rejected. status=%{public}d', resp.responseCode);
         return {
           success: false,
           accessToken: '',
@@ -111,6 +116,7 @@ export class AuthService {
       const parsed = JSON.parse(resp.body) as Record<string, string>;
       const accessToken = parsed['access_token'];
       if (!accessToken) {
+        hilog.warn(DOMAIN, TAG, 'refresh token response missing access token');
         return {
           success: false,
           accessToken: '',
@@ -126,6 +132,7 @@ export class AuthService {
         expiresIn: AuthService.expiresIn(parsed)
       };
     } catch (_) {
+      hilog.warn(DOMAIN, TAG, 'refresh token request failed');
       return {
         success: false,
         accessToken: '',

--- a/entry/src/main/ets/services/ExternalBusService.ets
+++ b/entry/src/main/ets/services/ExternalBusService.ets
@@ -81,11 +81,17 @@ export class ExternalBusService {
       type === 'scan_barcode';
   }
 
-  static buildExternalAuthCallbackScript(callback: string, success: boolean, token: string = ''): string {
+  static buildExternalAuthCallbackScript(
+    callback: string,
+    success: boolean,
+    token: string = '',
+    expiresIn: number = 0
+  ): string {
     const safeCallback = ExternalBusService.jsQuoted(callback);
     const safeToken = ExternalBusService.jsQuoted(token);
+    const safeExpiresIn = Number.isFinite(expiresIn) && expiresIn > 0 ? Math.ceil(expiresIn) : 0;
     return success
-      ? `(function(){var fn=window['${safeCallback}'];if(typeof fn==='function'){fn(true,{access_token:'${safeToken}',expires_in:1800});}})();`
+      ? `(function(){var fn=window['${safeCallback}'];if(typeof fn==='function'){fn(true,{access_token:'${safeToken}',expires_in:${safeExpiresIn}});}})();`
       : `(function(){var fn=window['${safeCallback}'];if(typeof fn==='function'){fn(false);}})();`;
   }
 

--- a/entry/src/main/ets/services/ServerAuthRepository.ets
+++ b/entry/src/main/ets/services/ServerAuthRepository.ets
@@ -20,8 +20,6 @@ class ServerAuthSessionPayload implements ServerAuthSession {
 }
 
 export class ServerAuthRepository {
-  private static readonly REFRESH_SKEW_MS: number = 2 * 60 * 1000;
-
   static loadSync(context: common.Context, serverInstanceId: string): ServerAuthSession {
     const id = serverInstanceId.trim();
     if (id.length === 0) {
@@ -57,8 +55,7 @@ export class ServerAuthRepository {
     const session = ServerAuthRepository.session(id, info);
     if (session.accessToken.length === 0) {
       if (session.refreshToken.length > 0) {
-        const refreshed = await ServerAuthRepository.refreshWithBaseUrl(context, id, refreshBaseUrl);
-        return refreshed.accessToken.length > 0 ? refreshed : session;
+        return ServerAuthRepository.refreshWithBaseUrl(context, id, refreshBaseUrl);
       }
       return session;
     }
@@ -67,7 +64,7 @@ export class ServerAuthRepository {
     }
     const refreshed = await ServerAuthRepository.refreshWithBaseUrl(context, id, refreshBaseUrl);
     if (refreshed.accessToken.length === 0) {
-      return session;
+      return refreshed;
     }
     if (refreshBaseUrl.trim().length > 0) {
       refreshed.baseUrl = refreshBaseUrl.trim();
@@ -111,7 +108,7 @@ export class ServerAuthRepository {
     if (info.refreshToken.trim().length === 0) {
       return false;
     }
-    return info.accessTokenExpiresAt <= Date.now() + ServerAuthRepository.REFRESH_SKEW_MS;
+    return info.accessTokenExpiresAt <= Date.now();
   }
 
   private static session(serverInstanceId: string, info: StoredServerInfo): ServerAuthSession {


### PR DESCRIPTION
## Summary

- Return an external-auth failure instead of a stale token when refresh fails.
- Pass the remaining access-token lifetime to the Home Assistant bridge while preserving a compatibility lifetime for access-only sessions.
- Add diagnostics for token refresh failures.

## Related Issue

Fixes #57

## Verification

- HarmonyOS version: Not run
- Device model: Not run
- API version: Not run
- `git diff --check`

## Checklist

- [x] The PR is scoped to a single change or closely related set of changes.
- [ ] User-facing behavior has been verified on a HarmonyOS device or emulator.
- [x] UI changes are not applicable.
- [x] New strings, icons, permissions, or configuration changes are intentional.
- [x] No local signing files, secrets, passwords, or generated build outputs are included.

## Additional Notes

Device verification remains pending.